### PR TITLE
Added missing class prefix to function pointers.

### DIFF
--- a/dlls/effects.cpp
+++ b/dlls/effects.cpp
@@ -427,7 +427,7 @@ LINK_ENTITY_TO_CLASS( trip_beam, CTripBeam );
 void CTripBeam::Spawn( void )
 {
 	CLightning::Spawn();
-	SetTouch( &CBeam::TriggerTouch );
+	SetTouch( &CTripBeam::TriggerTouch );
 	pev->solid = SOLID_TRIGGER;
 	RelinkBeam();
 }

--- a/dmc/dlls/effects.cpp
+++ b/dmc/dlls/effects.cpp
@@ -427,7 +427,7 @@ LINK_ENTITY_TO_CLASS( trip_beam, CTripBeam );
 void CTripBeam::Spawn( void )
 {
 	CLightning::Spawn();
-	SetTouch( &CBeam::TriggerTouch );
+	SetTouch( &CTripBeam::TriggerTouch );
 	pev->solid = SOLID_TRIGGER;
 	RelinkBeam();
 }

--- a/ricochet/dlls/effects.cpp
+++ b/ricochet/dlls/effects.cpp
@@ -427,7 +427,7 @@ LINK_ENTITY_TO_CLASS( trip_beam, CTripBeam );
 void CTripBeam::Spawn( void )
 {
 	CLightning::Spawn();
-	SetTouch( &CBeam::TriggerTouch );
+	SetTouch( &CTripBeam::TriggerTouch );
 	pev->solid = SOLID_TRIGGER;
 	RelinkBeam();
 }


### PR DESCRIPTION
Most of these are already fixed, just last ones remaining. VS gives an error if class pointers aren't prefixed with the class name.
