### PR TITLE
Update to smdlexp.vcxproj

### DIFF
--- a/projects/vs2010/smdlexp.vcxproj
+++ b/projects/vs2010/smdlexp.vcxproj
@@ -60,7 +60,7 @@
       <AdditionalDependencies>COMCTL32.LIB;maxutil.lib;geom.lib;mesh.lib;core.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>c:\3dsmax42\maxsdk\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <OutputFile>c:\3dsmax42\plugins\smdlexp.dle</OutputFile>
-      <ModuleDefinitionFile>$(MSBuildProjectDirectory)\..\..\utils\smdlexp\smdlexp.def</ModuleDefinitionFile>
+      <ModuleDefinitionFile>$(ProjectDir)..\..\utils\smdlexp\smdlexp.def</ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
       <Command>
@@ -85,6 +85,7 @@
       <AdditionalDependencies>COMCTL32.LIB;maxutil.lib;geom.lib;mesh.lib;core.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>c:\3dsmax42\maxsdk\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <OutputFile>c:\3dsmax42\plugins\smdlexp.dle</OutputFile>
+      <ModuleDefinitionFile>$(ProjectDir)..\..\utils\smdlexp\smdlexp.def</ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
       <Command>


### PR DESCRIPTION
Added a relative path to the required Module definition File smdlexp.def
found in halflife\utils\smdlexp\

Looks like so
http://s5.postimg.org/qgcdyurk7/relative_pathing.png

Although the project will compile fine without this step, 3DSMAX will
fail to load the plug-in giving errors such as "smdlexp.dle doesn't
implement LibVersion"

It seems that smdlexp.def needs to be explicitly defined in the vcxproj
in order to work.

tested and working with a custom model.
http://s5.postimg.org/6kgejbaiv/2014_07_21_0018.png

Much appreciation to @ripieces with help on the #1529 bug which led me to fixing this tiny issue
