### PR TITLE
Input code fixes

### DIFF
--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -32,7 +32,6 @@ int grgLogoFrame[MAX_LOGO_FRAMES] =
 };
 
 
-extern int g_iVisibleMouse;
 
 float HUD_GetFOV( void );
 

--- a/cl_dll/inputw32.cpp
+++ b/cl_dll/inputw32.cpp
@@ -26,12 +26,17 @@
 #include <SDL2/SDL_mouse.h>
 #include <SDL2/SDL_gamecontroller.h>
 
+#ifdef _WIN32
+#include <process.h>
+#endif
+
 #define MOUSE_BUTTON_COUNT 5
 
-// Set this to 1 to show mouse cursor.  Experimental
-int	g_iVisibleMouse = 0;
+// use IN_SetVisibleMouse to set:
+int	iVisibleMouse = 0;
 
 extern cl_enginefunc_t gEngfuncs;
+
 extern int iMouseInUse;
 
 extern kbutton_t	in_strafe;
@@ -54,10 +59,13 @@ extern cvar_t *cl_forwardspeed;
 extern cvar_t *cl_pitchspeed;
 extern cvar_t *cl_movespeedkey;
 
-
+#ifdef _WIN32
 static double s_flRawInputUpdateTime = 0.0f;
 static bool m_bRawInput = false;
 static bool m_bMouseThread = false;
+bool isMouseRelative = false;
+#endif
+
 extern globalvars_t *gpGlobals;
 
 // mouse variables
@@ -75,8 +83,10 @@ static cvar_t *m_customaccel_max;
 //Mouse move is raised to this power before being scaled by scale factor
 static cvar_t *m_customaccel_exponent;
 
+#ifdef _WIN32
 // if threaded mouse is enabled then the time to sleep between polls
-static cvar_t *m_mousethread_sleep;
+static volatile cvar_t *m_mousethread_sleep;
+#endif
 
 int			mouse_buttons;
 int			mouse_oldbuttonstate;
@@ -111,7 +121,6 @@ enum _ControlList
 	AxisSide,
 	AxisTurn
 };
-
 
 
 DWORD	dwAxisMap[ JOY_MAX_AXES ];
@@ -152,10 +161,10 @@ cvar_t	*joy_wwhack2;
 int			joy_avail, joy_advancedinit, joy_haspov;
 
 #ifdef _WIN32
-DWORD	s_hMouseThreadId = 0;
+unsigned int s_hMouseThreadId = 0;
 HANDLE	s_hMouseThread = 0;
 HANDLE	s_hMouseQuitEvent = 0;
-HANDLE	s_hMouseDoneQuitEvent = 0;
+HANDLE	s_hMouseThreadActiveLock = 0;
 #endif
 
 /*
@@ -176,48 +185,138 @@ void Force_CenterView_f (void)
 }
 
 #ifdef _WIN32
-long s_mouseDeltaX = 0;
-long s_mouseDeltaY = 0;
-POINT		old_mouse_pos;
 
-long ThreadInterlockedExchange( long *pDest, long value )
+long mouseThreadActive = 0;
+long mouseThreadCenterX = 0;
+long mouseThreadCenterY = 0;
+long mouseThreadDeltaX = 0;
+long mouseThreadDeltaY = 0;
+
+bool MouseThread_ActiveLock_Enter( void )
 {
-	return InterlockedExchange( pDest, value );
+	if(!m_bMouseThread)
+		return true;
+
+	return WAIT_OBJECT_0 == WaitForSingleObject( s_hMouseThreadActiveLock,  INFINITE);
 }
 
-
-DWORD WINAPI MousePos_ThreadFunction( LPVOID p )
+void MouseThread_ActiveLock_Exit( void )
 {
-	s_hMouseDoneQuitEvent = CreateEvent( NULL, FALSE, FALSE, NULL );
+	if(!m_bMouseThread)
+		return;
 
-	while ( 1 )
+	SetEvent( s_hMouseThreadActiveLock );
+}
+
+unsigned __stdcall MouseThread_Function( void * pArg )
+{
+	while ( true )
 	{
-		if ( WaitForSingleObject( s_hMouseQuitEvent, (int)m_mousethread_sleep->value ) == WAIT_OBJECT_0 )
+		int sleepVal = (int)m_mousethread_sleep->value;
+		if(0 > sleepVal) sleepVal = 0;
+		else if(1000 < sleepVal) sleepVal = 1000;
+		if(WAIT_OBJECT_0 == WaitForSingleObject( s_hMouseQuitEvent, sleepVal))
 		{
-			return 0;
+			break;
 		}
 
-		if ( mouseactive )
+		if( MouseThread_ActiveLock_Enter() )
 		{
-			POINT		mouse_pos;
-			GetCursorPos(&mouse_pos);
+			if ( InterlockedExchangeAdd(&mouseThreadActive, 0) )
+			{
+				POINT		mouse_pos;
+				POINT		center_pos;
+				
+				center_pos.x = InterlockedExchangeAdd(&mouseThreadCenterX, 0);
+				center_pos.y = InterlockedExchangeAdd(&mouseThreadCenterY, 0);
+				GetCursorPos(&mouse_pos);
 
-			volatile int mx = mouse_pos.x - old_mouse_pos.x + s_mouseDeltaX;
-			volatile int my = mouse_pos.y - old_mouse_pos.y + s_mouseDeltaY;
- 
-			ThreadInterlockedExchange( &old_mouse_pos.x, mouse_pos.x );
-			ThreadInterlockedExchange( &old_mouse_pos.y, mouse_pos.y );
+				mouse_pos.x -= center_pos.x;
+				mouse_pos.y -= center_pos.y;
 
-			ThreadInterlockedExchange( &s_mouseDeltaX, mx );
-			ThreadInterlockedExchange( &s_mouseDeltaY, my );
+				if(mouse_pos.x || mouse_pos.y) SetCursorPos( center_pos.x, center_pos.y );
+
+				InterlockedExchangeAdd(&mouseThreadDeltaX, mouse_pos.x);
+				InterlockedExchangeAdd(&mouseThreadDeltaY, mouse_pos.y);
+			}
+
+			MouseThread_ActiveLock_Exit();
 		}
 	}
 
-	SetEvent( s_hMouseDoneQuitEvent );
-
 	return 0;
 }
+
+/// <summary>Updates mouseThreadActive using the global variables mouseactive, iVisibleMouse and m_bRawInput. Should be called after any of these is changed.</summary>
+/// <remarks>Has to be interlocked manually by programmer! Use MouseThread_ActiveLock_Enter and MouseThread_ActiveLock_Exit.</remarks>
+void UpdateMouseThreadActive(void)
+{
+	InterlockedExchange(&mouseThreadActive, mouseactive && !iVisibleMouse && !m_bRawInput);
+}
+
 #endif
+
+void IN_SetMouseMode(bool enable)
+{
+	static bool currentMouseMode = false;
+	
+	if(enable == currentMouseMode)
+		return;
+
+	if(enable)
+	{
+#ifdef _WIN32
+		if (mouseparmsvalid)
+			restore_spi = SystemParametersInfo (SPI_SETMOUSE, 0, newmouseparms, 0);
+
+		m_bRawInput = CVAR_GET_FLOAT( "m_rawinput" ) != 0;
+		if(m_bRawInput)
+		{
+			SDL_SetRelativeMouseMode(SDL_TRUE);
+			isMouseRelative = true;
+		}
+#else
+		SDL_SetRelativeMouseMode(SDL_TRUE);
+#endif
+
+		currentMouseMode = true;
+	}
+	else
+	{
+#ifdef _WIN32
+		if(isMouseRelative)
+		{
+			SDL_SetRelativeMouseMode(SDL_FALSE);
+			isMouseRelative = false;
+		}
+
+		if (restore_spi)
+			SystemParametersInfo (SPI_SETMOUSE, 0, originalmouseparms, 0);
+#else
+		SDL_SetRelativeMouseMode(SDL_FALSE);
+#endif
+
+		currentMouseMode = false;
+	}
+}
+
+void IN_SetVisibleMouse(bool visible)
+{
+#ifdef _WIN32
+	bool lockEntered = MouseThread_ActiveLock_Enter();
+#endif
+
+	iVisibleMouse = visible;
+
+	IN_SetMouseMode(!visible);
+
+#ifdef _WIN32
+	UpdateMouseThreadActive();
+	if(lockEntered) MouseThread_ActiveLock_Exit();
+#endif
+}
+
+void IN_ResetMouse( void );
 
 /*
 ===========
@@ -229,11 +328,20 @@ void CL_DLLEXPORT IN_ActivateMouse (void)
 	if (mouseinitialized)
 	{
 #ifdef _WIN32
-		if (mouseparmsvalid)
-			restore_spi = SystemParametersInfo (SPI_SETMOUSE, 0, newmouseparms, 0);
-
+		bool lockEntered = MouseThread_ActiveLock_Enter();
 #endif
+
+		IN_SetMouseMode(true);
+
 		mouseactive = 1;
+
+#ifdef _WIN32
+		UpdateMouseThreadActive();
+		if(lockEntered) MouseThread_ActiveLock_Exit();
+#endif
+
+		// now is a good time to reset mouse positon:
+		IN_ResetMouse();
 	}
 }
 
@@ -248,12 +356,17 @@ void CL_DLLEXPORT IN_DeactivateMouse (void)
 	if (mouseinitialized)
 	{
 #ifdef _WIN32
-		if (restore_spi)
-			SystemParametersInfo (SPI_SETMOUSE, 0, originalmouseparms, 0);
-
+		bool lockEntered = MouseThread_ActiveLock_Enter();
 #endif
 
+		IN_SetMouseMode(false);
+
 		mouseactive = 0;
+
+#ifdef _WIN32
+		UpdateMouseThreadActive();
+		if(lockEntered) MouseThread_ActiveLock_Exit();
+#endif
 	}
 }
 
@@ -307,12 +420,14 @@ void IN_Shutdown (void)
 	if ( s_hMouseQuitEvent )
 	{
 		SetEvent( s_hMouseQuitEvent );
-		WaitForSingleObject( s_hMouseDoneQuitEvent, 100 );
 	}
 	
 	if ( s_hMouseThread )
 	{
-		TerminateThread( s_hMouseThread, 0 );
+		if(WAIT_OBJECT_0 != WaitForSingleObject( s_hMouseThread, 5000 ))
+		{
+			TerminateThread( s_hMouseThread, 0 );
+		}
 		CloseHandle( s_hMouseThread );
 		s_hMouseThread = (HANDLE)0;
 	}
@@ -322,12 +437,11 @@ void IN_Shutdown (void)
 		CloseHandle( s_hMouseQuitEvent );
 		s_hMouseQuitEvent = (HANDLE)0;
 	}
-	
-	
-	if ( s_hMouseDoneQuitEvent )
+
+	if( s_hMouseThreadActiveLock )
 	{
-		CloseHandle( s_hMouseDoneQuitEvent );
-		s_hMouseDoneQuitEvent = (HANDLE)0;
+		CloseHandle( s_hMouseThreadActiveLock );
+		s_hMouseThreadActiveLock = (HANDLE)0;
 	}
 #endif
 }
@@ -355,18 +469,24 @@ void IN_ResetMouse( void )
 {
 	// no work to do in SDL
 #ifdef _WIN32
-	if ( !m_bRawInput && mouseactive && gEngfuncs.GetWindowCenterX && gEngfuncs.GetWindowCenterY )
+	// reset only if mouse is active and not in visible mode:
+	if(mouseactive && !iVisibleMouse)
 	{
+		if ( !m_bRawInput && gEngfuncs.GetWindowCenterX && gEngfuncs.GetWindowCenterY )
+		{
+			bool lockEntered = MouseThread_ActiveLock_Enter();
 
-		SetCursorPos ( gEngfuncs.GetWindowCenterX(), gEngfuncs.GetWindowCenterY() );
-		ThreadInterlockedExchange( &old_mouse_pos.x, gEngfuncs.GetWindowCenterX() );
-		ThreadInterlockedExchange( &old_mouse_pos.y, gEngfuncs.GetWindowCenterY() );
-	}
+			int centerX = gEngfuncs.GetWindowCenterX();
+			int centerY = gEngfuncs.GetWindowCenterY();
 
-	if ( gpGlobals && gpGlobals->time - s_flRawInputUpdateTime > 1.0f )
-	{
-		s_flRawInputUpdateTime = gpGlobals->time;
-		m_bRawInput = CVAR_GET_FLOAT( "m_rawinput" ) != 0;
+			SetCursorPos ( centerX, centerY );
+			InterlockedExchange( &mouseThreadCenterX, centerX );
+			InterlockedExchange( &mouseThreadCenterY, centerY );
+			InterlockedExchange( &mouseThreadDeltaX, 0 );
+			InterlockedExchange( &mouseThreadDeltaY, 0 );
+
+			if(lockEntered) MouseThread_ActiveLock_Exit();
+		}
 	}
 #endif
 }
@@ -380,7 +500,7 @@ void CL_DLLEXPORT IN_MouseEvent (int mstate)
 {
 	int		i;
 
-	if ( iMouseInUse || g_iVisibleMouse )
+	if ( iMouseInUse || iVisibleMouse )
 		return;
 
 	// perform button actions
@@ -451,26 +571,12 @@ void IN_ScaleMouse( float *x, float *y )
 	}
 }
 
-/*
-===========
-IN_MouseMove
-===========
-*/
-void IN_MouseMove ( float frametime, usercmd_t *cmd)
+void IN_GetMouseDelta( int *pOutX, int *pOutY)
 {
-	int		mx, my;
-	vec3_t viewangles;
+	bool active = mouseactive && !iVisibleMouse;
+	int mx, my;
 
-	gEngfuncs.GetViewAngles( (float *)viewangles );
-
-	if ( in_mlook.state & 1)
-	{
-		V_StopPitchDrift ();
-	}
-
-	//jjb - this disbles normal mouse control if the user is trying to 
-	//      move the camera, or if the mouse cursor is visible or if we're in intermission
-	if ( !iMouseInUse && !gHUD.m_iIntermission && !g_iVisibleMouse )
+	if(active)
 	{
 		int deltaX, deltaY;
 #ifdef _WIN32
@@ -478,10 +584,12 @@ void IN_MouseMove ( float frametime, usercmd_t *cmd)
 		{
 			if ( m_bMouseThread )
 			{
-				ThreadInterlockedExchange( &current_pos.x, s_mouseDeltaX );
-				ThreadInterlockedExchange( &current_pos.y, s_mouseDeltaY );
-				ThreadInterlockedExchange( &s_mouseDeltaX, 0 );
-				ThreadInterlockedExchange( &s_mouseDeltaY, 0 );
+				bool lockEntered = MouseThread_ActiveLock_Enter();
+
+				current_pos.x = InterlockedExchange( &mouseThreadDeltaX, 0 );
+				current_pos.y = InterlockedExchange( &mouseThreadDeltaY, 0 );
+
+				if(lockEntered) MouseThread_ActiveLock_Exit();
 			}
 			else
 			{
@@ -519,6 +627,73 @@ void IN_MouseMove ( float frametime, usercmd_t *cmd)
 		
 		mx_accum = 0;
 		my_accum = 0;
+
+		// reset mouse position if required, so there is room to move:
+#ifdef _WIN32
+		// do not reset if mousethread would do it:
+		if ( m_bRawInput || !m_bMouseThread )
+#else
+		if(true)
+#endif
+			IN_ResetMouse();
+
+#ifdef _WIN32
+		// update m_bRawInput occasionally: 
+		if ( gpGlobals && gpGlobals->time - s_flRawInputUpdateTime > 1.0f )
+		{
+			s_flRawInputUpdateTime = gpGlobals->time;
+
+			bool lockEntered = MouseThread_ActiveLock_Enter();
+
+			m_bRawInput = CVAR_GET_FLOAT( "m_rawinput" ) != 0;
+
+			if(m_bRawInput && !isMouseRelative)
+			{
+				SDL_SetRelativeMouseMode(SDL_TRUE);
+				isMouseRelative = true;
+			}
+			else if(!m_bRawInput && isMouseRelative)
+			{
+				SDL_SetRelativeMouseMode(SDL_FALSE);
+				isMouseRelative = false;
+			}
+
+			UpdateMouseThreadActive();
+			if(lockEntered) MouseThread_ActiveLock_Exit();
+		}
+#endif
+	}
+	else
+	{
+		mx = my = 0;
+	}
+
+	if(pOutX) *pOutX = mx;
+	if(pOutY) *pOutY = my;
+}
+
+/*
+===========
+IN_MouseMove
+===========
+*/
+void IN_MouseMove ( float frametime, usercmd_t *cmd)
+{
+	int		mx, my;
+	vec3_t viewangles;
+
+	gEngfuncs.GetViewAngles( (float *)viewangles );
+
+	if ( in_mlook.state & 1)
+	{
+		V_StopPitchDrift ();
+	}
+
+	//jjb - this disbles normal mouse control if the user is trying to 
+	//      move the camera, or if the mouse cursor is visible or if we're in intermission
+	if ( !iMouseInUse && !gHUD.m_iIntermission && !iVisibleMouse )
+	{
+		IN_GetMouseDelta( &mx, &my );
 
 		if (m_filter && m_filter->value)
 		{
@@ -562,12 +737,6 @@ void IN_MouseMove ( float frametime, usercmd_t *cmd)
 				cmd->forwardmove -= m_forward->value * mouse_y;
 			}
 		}
-
-		// if the mouse has moved, force it to the center, so there's room to move
-		if ( mx || my )
-		{
-			IN_ResetMouse();
-		}
 	}
 
 	gEngfuncs.SetViewAngles( (float *)viewangles );
@@ -593,7 +762,7 @@ IN_Accumulate
 void CL_DLLEXPORT IN_Accumulate (void)
 {
 	//only accumulate mouse if we are not moving the camera with the mouse
-	if ( !iMouseInUse && !g_iVisibleMouse)
+	if ( !iMouseInUse && !iVisibleMouse)
 	{
 	    if (mouseactive)
 	    {
@@ -616,8 +785,15 @@ void CL_DLLEXPORT IN_Accumulate (void)
 				mx_accum += deltaX;
 				my_accum += deltaY;	
 			}
+
 			// force the mouse to the center, so there's room to move
-			IN_ResetMouse();
+#ifdef _WIN32
+			// do not reset if mousethread would do it:
+			if ( m_bRawInput || !m_bMouseThread )
+#else
+			if(true)
+#endif
+				IN_ResetMouse();
 			
 		}
 	}
@@ -649,10 +825,10 @@ void IN_StartupJoystick (void)
 	// abort startup if user requests no joystick
 	if ( gEngfuncs.CheckParm ("-nojoy", NULL ) ) 
 		return; 
- 
- 	// assume no joystick
+	
+	// assume no joystick
 	joy_avail = 0; 
-
+	
 	int nJoysticks = SDL_NumJoysticks();
 	if ( nJoysticks > 0 )
 	{
@@ -677,7 +853,6 @@ void IN_StartupJoystick (void)
 					joy_advancedinit = 0;
 					break;
 				}
-
 			}
 		}
 	}
@@ -685,23 +860,21 @@ void IN_StartupJoystick (void)
 	{
 		gEngfuncs.Con_DPrintf ("joystick not found -- driver not present\n\n");
 	}
-	
 }
-
 
 int RawValuePointer (int axis)
 {
 	switch (axis)
 	{
-		default:
-		case JOY_AXIS_X:
-			return SDL_GameControllerGetAxis( s_pJoystick, SDL_CONTROLLER_AXIS_LEFTX );
-		case JOY_AXIS_Y:
-			return SDL_GameControllerGetAxis( s_pJoystick, SDL_CONTROLLER_AXIS_LEFTY );
-		case JOY_AXIS_Z:
-			return SDL_GameControllerGetAxis( s_pJoystick, SDL_CONTROLLER_AXIS_RIGHTX );
-		case JOY_AXIS_R:
-			return SDL_GameControllerGetAxis( s_pJoystick, SDL_CONTROLLER_AXIS_RIGHTY );
+	default:
+	case JOY_AXIS_X:
+		return SDL_GameControllerGetAxis( s_pJoystick, SDL_CONTROLLER_AXIS_LEFTX );
+	case JOY_AXIS_Y:
+		return SDL_GameControllerGetAxis( s_pJoystick, SDL_CONTROLLER_AXIS_LEFTY );
+	case JOY_AXIS_Z:
+		return SDL_GameControllerGetAxis( s_pJoystick, SDL_CONTROLLER_AXIS_RIGHTX );
+	case JOY_AXIS_R:
+		return SDL_GameControllerGetAxis( s_pJoystick, SDL_CONTROLLER_AXIS_RIGHTY );
 		
 	}
 }
@@ -1090,19 +1263,25 @@ void IN_Init (void)
 	m_customaccel_exponent	= gEngfuncs.pfnRegisterVariable ( "m_customaccel_exponent", "1", FCVAR_ARCHIVE );
 
 #ifdef _WIN32
-	m_bRawInput				= CVAR_GET_FLOAT( "m_rawinput" ) > 0;
+	m_bRawInput				= CVAR_GET_FLOAT( "m_rawinput" ) != 0;
 	m_bMouseThread			= gEngfuncs.CheckParm ("-mousethread", NULL ) != NULL;
-	m_mousethread_sleep			= gEngfuncs.pfnRegisterVariable ( "m_mousethread_sleep", "10", FCVAR_ARCHIVE );
+	m_mousethread_sleep		= gEngfuncs.pfnRegisterVariable ( "m_mousethread_sleep", "1", FCVAR_ARCHIVE ); // default to less than 1000 Hz
 
-	if ( !m_bRawInput && m_bMouseThread && m_mousethread_sleep ) 
+	m_bMouseThread = m_bMouseThread && NULL != m_mousethread_sleep;
+
+	if (m_bMouseThread) 
 	{
-		s_mouseDeltaX = s_mouseDeltaY = 0;
-		
 		s_hMouseQuitEvent = CreateEvent( NULL, FALSE, FALSE, NULL );
-		if ( s_hMouseQuitEvent )
+		s_hMouseThreadActiveLock = CreateEvent( NULL, FALSE, TRUE, NULL );
+		if ( s_hMouseQuitEvent && s_hMouseThreadActiveLock)
 		{
-			s_hMouseThread = CreateThread( NULL, 0, MousePos_ThreadFunction, NULL, 0, &s_hMouseThreadId );
+			s_hMouseThread = (HANDLE)_beginthreadex( NULL, 0, MouseThread_Function, NULL, 0, &s_hMouseThreadId );
 		}
+
+		m_bMouseThread = NULL != s_hMouseThread;
+
+		// at this early stage this won't print anything:
+		// gEngfuncs.Con_DPrintf ("Mouse thread %s.\n", m_bMouseThread ? "initalized" : "failed to initalize");
 	}
 #endif
 

--- a/cl_dll/vgui_TeamFortressViewport.cpp
+++ b/cl_dll/vgui_TeamFortressViewport.cpp
@@ -58,7 +58,7 @@
 #include "shake.h"
 #include "screenfade.h"
 
-extern int g_iVisibleMouse;
+void IN_SetVisibleMouse(bool visible);
 class CCommandMenu;
 int g_iPlayerClass;
 int g_iTeamNumber;
@@ -2060,7 +2060,7 @@ void TeamFortressViewport::UpdateCursorState()
 	// Need cursor if any VGUI window is up
 	if ( m_pSpectatorPanel->m_menuVisible || m_pCurrentMenu || m_pTeamMenu->isVisible() || m_pServerBrowser->isVisible() || GetClientVoiceMgr()->IsInSquelchMode() )
 	{
-		g_iVisibleMouse = true;
+		IN_SetVisibleMouse(true);
 		App::getInstance()->setCursorOveride( App::getInstance()->getScheme()->getCursor(Scheme::scu_arrow) );
 		return;
 	}
@@ -2069,20 +2069,20 @@ void TeamFortressViewport::UpdateCursorState()
 		// commandmenu doesn't have cursor if hud_capturemouse is turned off
 		if ( gHUD.m_pCvarStealMouse->value != 0.0f )
 		{
-			g_iVisibleMouse = true;
+			IN_SetVisibleMouse(true);
 			App::getInstance()->setCursorOveride( App::getInstance()->getScheme()->getCursor(Scheme::scu_arrow) );
 			return;
 		}
 	}
+
+	App::getInstance()->setCursorOveride( App::getInstance()->getScheme()->getCursor(Scheme::scu_none) );
+	IN_SetVisibleMouse(false);
 
 	// Don't reset mouse in demo playback
 	if ( !gEngfuncs.pDemoAPI->IsPlayingback() )
 	{
 		IN_ResetMouse();
 	}
-
-	g_iVisibleMouse = false;
-	App::getInstance()->setCursorOveride( App::getInstance()->getScheme()->getCursor(Scheme::scu_none) );
 }
 
 void TeamFortressViewport::UpdateHighlights()

--- a/dmc/cl_dll/hud_redraw.cpp
+++ b/dmc/cl_dll/hud_redraw.cpp
@@ -21,8 +21,6 @@
 #include <string.h>
 #include "vgui_viewport.h"
 
-extern int g_iVisibleMouse;
-
 #define MAX_LOGO_FRAMES 56
 
 int grgLogoFrame[MAX_LOGO_FRAMES] = 

--- a/dmc/cl_dll/in_camera.cpp
+++ b/dmc/cl_dll/in_camera.cpp
@@ -14,18 +14,11 @@
 #include "const.h"
 #include "camera.h"
 #include "in_defs.h"
+#include "Exports.h"
 
-#include "SDL2/SDL_mouse.h"
 #include "port.h"
 
 float CL_KeyState (kbutton_t *key);
-
-extern "C" 
-{
-	void EXPORT CAM_Think( void );
-	int EXPORT CL_IsThirdPerson( void );
-	void EXPORT CL_CameraOffset( float *ofs );
-}
 
 extern cl_enginefunc_t gEngfuncs;
 
@@ -35,12 +28,13 @@ extern cl_enginefunc_t gEngfuncs;
 #define CAM_ANGLE_DELTA 2.5
 #define CAM_ANGLE_SPEED 2.5
 #define CAM_MIN_DIST 30.0
-#define CAM_ANGLE_MOVE .5
 #define MAX_ANGLE_DIFF 10.0
 #define PITCH_MAX 90.0
 #define PITCH_MIN 0
 #define YAW_MAX  135.0
 #define YAW_MIN	 -135.0
+#define CAM_DIST_MOUSEFAC 0.05
+#define CAM_ANGLE_MOUSEFAC 1.67
 
 enum ECAM_Command
 {
@@ -50,6 +44,11 @@ enum ECAM_Command
 };
 
 //-------------------------------------------------- Global Variables
+
+extern cvar_t	*m_pitch;
+extern cvar_t	*m_yaw;
+extern cvar_t	*m_forward;
+extern cvar_t	*m_side;
 
 cvar_t	*cam_command;
 cvar_t	*cam_snapto;
@@ -74,9 +73,7 @@ int cam_thirdperson;
 int cam_mousemove; //true if we are moving the cam with the mouse, False if not
 int iMouseInUse=0;
 int cam_distancemove;
-extern int mouse_x, mouse_y;  //used to determine what the current x and y values are
-int cam_old_mouse_x, cam_old_mouse_y; //holds the last ticks mouse movement
-POINT		cam_mouse;
+
 //-------------------------------------------------- Local Variables
 
 static kbutton_t cam_pitchup, cam_pitchdown, cam_yawleft, cam_yawright;
@@ -89,15 +86,27 @@ void CAM_ToFirstPerson(void);
 void CAM_StartDistance(void);
 void CAM_EndDistance(void);
 
-void SDL_GetCursorPos( POINT *p )
-{
-	SDL_GetMouseState( (int *)&p->x, (int *)&p->y );
-}
+//--------------------------------------------------
 
-void SDL_SetCursorPos( const int x, const int y )
-{
-}
+// defined in inputw32.cpp:
+void IN_GetMouseDelta( int *pOutX, int *pOuty);
+void IN_ScaleMouse( float *x, float *y );
 
+void CAM_GetScaledMouseDelta( float *pOutX, float *pOutY )
+{
+	int x,y;
+	float fx, fy;
+
+	IN_GetMouseDelta( &x, &y );
+
+	fx = x;
+	fy = y;
+
+	IN_ScaleMouse( &fx, &fy );
+
+	if(pOutX) *pOutX = fx;
+	if(pOutY) *pOutY = fy;
+}
 
 //-------------------------------------------------- Local Functions
 
@@ -156,14 +165,14 @@ typedef struct
 
 extern trace_t SV_ClipMoveToEntity (edict_t *ent, vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end);
 
-void EXPORT CAM_Think( void )
+void CL_DLLEXPORT CAM_Think( void )
 {
+	float cam_mouse_x, cam_mouse_y;
 	vec3_t origin;
 	vec3_t ext, pnt, camForward, camRight, camUp;
 	moveclip_t	clip;
 	float dist;
 	vec3_t camAngles;
-	float flSensitivity;
 #ifdef LATER
 	int i;
 #endif
@@ -203,8 +212,8 @@ void EXPORT CAM_Think( void )
 	//
 	if (cam_mousemove)
 	{
-	    //get windows cursor position
-		SDL_GetCursorPos (&cam_mouse);
+	    //get mouse cursor delta
+		CAM_GetScaledMouseDelta (&cam_mouse_x,&cam_mouse_y);
 		//check for X delta values and adjust accordingly
 		//eventually adjust YAW based on amount of movement
 	  //don't do any movement of the cam using YAW/PITCH if we are zooming in/out the camera	
@@ -212,12 +221,12 @@ void EXPORT CAM_Think( void )
 	  {
 		
 		//keep the camera within certain limits around the player (ie avoid certain bad viewing angles)  
-		if (cam_mouse.x>gEngfuncs.GetWindowCenterX())
+		if (cam_mouse_x>0)
 		{
 			//if ((camAngles[YAW]>=225.0)||(camAngles[YAW]<135.0))
 			if (camAngles[YAW]<c_maxyaw->value)
 			{
-				camAngles[ YAW ] += (CAM_ANGLE_MOVE)*((cam_mouse.x-gEngfuncs.GetWindowCenterX())/2);
+				camAngles[ YAW ] += CAM_ANGLE_MOUSEFAC * m_yaw->value * cam_mouse_x;
 			}
 			if (camAngles[YAW]>c_maxyaw->value)
 			{
@@ -225,12 +234,12 @@ void EXPORT CAM_Think( void )
 				camAngles[YAW]=c_maxyaw->value;
 			}
 		}
-		else if (cam_mouse.x<gEngfuncs.GetWindowCenterX())
+		else if (cam_mouse_x<0)
 		{
 			//if ((camAngles[YAW]<=135.0)||(camAngles[YAW]>225.0))
 			if (camAngles[YAW]>c_minyaw->value)
 			{
-			   camAngles[ YAW ] -= (CAM_ANGLE_MOVE)* ((gEngfuncs.GetWindowCenterX()-cam_mouse.x)/2);
+			   camAngles[ YAW ] -= CAM_ANGLE_MOUSEFAC * m_yaw->value * -cam_mouse_x;
 			   	
 			}
 			if (camAngles[YAW]<c_minyaw->value)
@@ -243,43 +252,28 @@ void EXPORT CAM_Think( void )
 		//check for y delta values and adjust accordingly
 		//eventually adjust PITCH based on amount of movement
 		//also make sure camera is within bounds
-		if (cam_mouse.y>gEngfuncs.GetWindowCenterY())
+		if (cam_mouse_y>0)
 		{
 			if(camAngles[PITCH]<c_maxpitch->value)
 			{
-			    camAngles[PITCH] +=(CAM_ANGLE_MOVE)* ((cam_mouse.y-gEngfuncs.GetWindowCenterY())/2);
+			    camAngles[PITCH] += CAM_ANGLE_MOUSEFAC * m_pitch->value * cam_mouse_y;
 			}
 			if (camAngles[PITCH]>c_maxpitch->value)
 			{
 				camAngles[PITCH]=c_maxpitch->value;
 			}
 		}
-		else if (cam_mouse.y<gEngfuncs.GetWindowCenterY())
+		else if (cam_mouse_y<0)
 		{
 			if (camAngles[PITCH]>c_minpitch->value)
 			{
-			   camAngles[PITCH] -= (CAM_ANGLE_MOVE)*((gEngfuncs.GetWindowCenterY()-cam_mouse.y)/2);
+			   camAngles[PITCH] -= CAM_ANGLE_MOUSEFAC * m_pitch->value * -cam_mouse_y;
 			}
 			if (camAngles[PITCH]<c_minpitch->value)
 			{
 				camAngles[PITCH]=c_minpitch->value;
 			}
 		}
-
-		//set old mouse coordinates to current mouse coordinates
-		//since we are done with the mouse
-
-		if ( ( flSensitivity = gHUD.GetSensitivity() ) != 0 )
-		{
-			cam_old_mouse_x=cam_mouse.x*flSensitivity;
-			cam_old_mouse_y=cam_mouse.y*flSensitivity;
-		}
-		else
-		{
-			cam_old_mouse_x=cam_mouse.x;
-			cam_old_mouse_y=cam_mouse.y;
-		}
-		SDL_SetCursorPos (gEngfuncs.GetWindowCenterX(), gEngfuncs.GetWindowCenterY());
 	  }
 	}
 
@@ -311,33 +305,28 @@ void EXPORT CAM_Think( void )
 
 	if (cam_distancemove)
 	{
-		if (cam_mouse.y>gEngfuncs.GetWindowCenterY())
+		if (cam_mouse_y>0)
 		{
 			if(dist<c_maxdistance->value)
 			{
-			    dist +=CAM_DIST_DELTA * ((cam_mouse.y-gEngfuncs.GetWindowCenterY())/2);
+			    dist += CAM_DIST_MOUSEFAC * m_forward->value * cam_mouse_y;
 			}
 			if (dist>c_maxdistance->value)
 			{
 				dist=c_maxdistance->value;
 			}
 		}
-		else if (cam_mouse.y<gEngfuncs.GetWindowCenterY())
+		else if (cam_mouse_y<0)
 		{
 			if (dist>c_mindistance->value)
 			{
-			   dist -= (CAM_DIST_DELTA)*((gEngfuncs.GetWindowCenterY()-cam_mouse.y)/2);
+			   dist -= CAM_DIST_MOUSEFAC * m_forward->value * -cam_mouse_y;
 			}
 			if (dist<c_mindistance->value)
 			{
 				dist=c_mindistance->value;
 			}
 		}
-		//set old mouse coordinates to current mouse coordinates
-		//since we are done with the mouse
-		cam_old_mouse_x=cam_mouse.x*gHUD.GetSensitivity();
-		cam_old_mouse_y=cam_mouse.y*gHUD.GetSensitivity();
-		SDL_SetCursorPos (gEngfuncs.GetWindowCenterX(), gEngfuncs.GetWindowCenterY());
 	}
 #ifdef LATER
 	if( cam_contain->value )
@@ -536,29 +525,14 @@ void CAM_ClearStates( void )
 
 void CAM_StartMouseMove(void)
 {
-	float flSensitivity;
-		
 	//only move the cam with mouse if we are in third person.
 	if (cam_thirdperson)
 	{
-		//set appropriate flags and initialize the old mouse position
-		//variables for mouse camera movement
+		//set appropriate flags
 		if (!cam_mousemove)
 		{
 			cam_mousemove=1;
 			iMouseInUse=1;
-			SDL_GetCursorPos (&cam_mouse);
-
-			if ( ( flSensitivity = gHUD.GetSensitivity() ) != 0 )
-			{
-				cam_old_mouse_x=cam_mouse.x*flSensitivity;
-				cam_old_mouse_y=cam_mouse.y*flSensitivity;
-			}
-			else
-			{
-				cam_old_mouse_x=cam_mouse.x;
-				cam_old_mouse_y=cam_mouse.y;
-			}
 		}
 	}
 	//we are not in 3rd person view..therefore do not allow camera movement
@@ -587,16 +561,12 @@ void CAM_StartDistance(void)
 	//only move the cam with mouse if we are in third person.
 	if (cam_thirdperson)
 	{
-	  //set appropriate flags and initialize the old mouse position
-	  //variables for mouse camera movement
+	  //set appropriate flags
 	  if (!cam_distancemove)
 	  {
 		  cam_distancemove=1;
 		  cam_mousemove=1;
 		  iMouseInUse=1;
-		  SDL_GetCursorPos (&cam_mouse);
-		  cam_old_mouse_x=cam_mouse.x*gHUD.GetSensitivity();
-		  cam_old_mouse_y=cam_mouse.y*gHUD.GetSensitivity();
 	  }
 	}
 	//we are not in 3rd person view..therefore do not allow camera movement
@@ -617,12 +587,12 @@ void CAM_EndDistance(void)
    iMouseInUse=0;
 }
 
-int EXPORT CL_IsThirdPerson( void )
+int CL_DLLEXPORT CL_IsThirdPerson( void )
 {
 	return cam_thirdperson ? 1 : 0;
 }
 
-void EXPORT CL_CameraOffset( float *ofs )
+void CL_DLLEXPORT CL_CameraOffset( float *ofs )
 {
 	VectorCopy( cam_ofs, ofs );
 }

--- a/dmc/cl_dll/vgui_viewport.cpp
+++ b/dmc/cl_dll/vgui_viewport.cpp
@@ -56,7 +56,7 @@
 #include "vgui_SpectatorPanel.h"
 #include "voice_status.h"
 
-extern int g_iVisibleMouse;
+void IN_SetVisibleMouse(bool visible);
 class CCommandMenu;
 int g_iPlayerClass;
 int g_iTeamNumber;
@@ -1521,7 +1521,7 @@ void TeamFortressViewport::UpdateCursorState()
 	// Need cursor if any VGUI window is up
 	if ( m_pSpectatorPanel->m_menuVisible || m_pCurrentMenu || m_pServerBrowser->isVisible() || GetClientVoiceMgr()->IsInSquelchMode() )
 	{
-		g_iVisibleMouse = true;
+		IN_SetVisibleMouse(true);
 		App::getInstance()->setCursorOveride( App::getInstance()->getScheme()->getCursor(Scheme::scu_arrow) );
 		return;
 	}
@@ -1530,15 +1530,15 @@ void TeamFortressViewport::UpdateCursorState()
 		// commandmenu doesn't have cursor if hud_capturemouse is turned off
 		if ( gHUD.m_pCvarStealMouse->value != 0.0f )
 		{
-			g_iVisibleMouse = true;
+			IN_SetVisibleMouse(true);
 			App::getInstance()->setCursorOveride( App::getInstance()->getScheme()->getCursor(Scheme::scu_arrow) );
 			return;
 		}
 	}
 
-	IN_ResetMouse();
-	g_iVisibleMouse = false;
 	App::getInstance()->setCursorOveride( App::getInstance()->getScheme()->getCursor(Scheme::scu_none) );
+	IN_SetVisibleMouse(false);
+	IN_ResetMouse();
 }
 
 void TeamFortressViewport::UpdateHighlights()

--- a/ricochet/cl_dll/hud_redraw.cpp
+++ b/ricochet/cl_dll/hud_redraw.cpp
@@ -29,8 +29,6 @@ int grgLogoFrame[MAX_LOGO_FRAMES] =
 	29, 29, 29, 29, 29, 28, 27, 26, 25, 24, 30, 31 
 };
 
-extern int g_iVisibleMouse;
-
 // Think
 void CHud::Think(void)
 {

--- a/ricochet/cl_dll/in_camera.cpp
+++ b/ricochet/cl_dll/in_camera.cpp
@@ -21,18 +21,11 @@
 #include "const.h"
 #include "camera.h"
 #include "in_defs.h"
+#include "Exports.h"
 
-#include "SDL2/SDL_mouse.h"
 #include "port.h"
 
 float CL_KeyState (kbutton_t *key);
-
-extern "C" 
-{
-	void EXPORT CAM_Think( void );
-	int EXPORT CL_IsThirdPerson( void );
-	void EXPORT CL_CameraOffset( float *ofs );
-}
 
 extern cl_enginefunc_t gEngfuncs;
 
@@ -42,12 +35,13 @@ extern cl_enginefunc_t gEngfuncs;
 #define CAM_ANGLE_DELTA 2.5
 #define CAM_ANGLE_SPEED 2.5
 #define CAM_MIN_DIST 30.0
-#define CAM_ANGLE_MOVE .5
 #define MAX_ANGLE_DIFF 10.0
 #define PITCH_MAX 90.0
 #define PITCH_MIN 0
 #define YAW_MAX  135.0
 #define YAW_MIN	 -135.0
+#define CAM_DIST_MOUSEFAC 0.05
+#define CAM_ANGLE_MOUSEFAC 1.67
 
 enum ECAM_Command
 {
@@ -57,6 +51,11 @@ enum ECAM_Command
 };
 
 //-------------------------------------------------- Global Variables
+
+extern cvar_t	*m_pitch;
+extern cvar_t	*m_yaw;
+extern cvar_t	*m_forward;
+extern cvar_t	*m_side;
 
 cvar_t	*cam_command;
 cvar_t	*cam_snapto;
@@ -81,9 +80,7 @@ int cam_thirdperson;
 int cam_mousemove; //true if we are moving the cam with the mouse, False if not
 int iMouseInUse=0;
 int cam_distancemove;
-extern int mouse_x, mouse_y;  //used to determine what the current x and y values are
-int cam_old_mouse_x, cam_old_mouse_y; //holds the last ticks mouse movement
-POINT		cam_mouse;
+
 //-------------------------------------------------- Local Variables
 
 static kbutton_t cam_pitchup, cam_pitchdown, cam_yawleft, cam_yawright;
@@ -96,15 +93,27 @@ void CAM_ToFirstPerson(void);
 void CAM_StartDistance(void);
 void CAM_EndDistance(void);
 
-void SDL_GetCursorPos( POINT *p )
-{
-	SDL_GetMouseState( (int *)&p->x, (int *)&p->y );
-}
+//--------------------------------------------------
 
-void SDL_SetCursorPos( const int x, const int y )
-{
-}
+// defined in inputw32.cpp:
+void IN_GetMouseDelta( int *pOutX, int *pOuty);
+void IN_ScaleMouse( float *x, float *y );
 
+void CAM_GetScaledMouseDelta( float *pOutX, float *pOutY )
+{
+	int x,y;
+	float fx, fy;
+
+	IN_GetMouseDelta( &x, &y );
+
+	fx = x;
+	fy = y;
+
+	IN_ScaleMouse( &fx, &fy );
+
+	if(pOutX) *pOutX = fx;
+	if(pOutY) *pOutY = fy;
+}
 
 //-------------------------------------------------- Local Functions
 
@@ -163,14 +172,14 @@ typedef struct
 
 extern trace_t SV_ClipMoveToEntity (edict_t *ent, vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end);
 
-void EXPORT CAM_Think( void )
+void CL_DLLEXPORT CAM_Think( void )
 {
+	float cam_mouse_x, cam_mouse_y;
 	vec3_t origin;
 	vec3_t ext, pnt, camForward, camRight, camUp;
 	moveclip_t	clip;
 	float dist;
 	vec3_t camAngles;
-	float flSensitivity;
 #ifdef LATER
 	int i;
 #endif
@@ -210,8 +219,8 @@ void EXPORT CAM_Think( void )
 	//
 	if (cam_mousemove)
 	{
-	    //get windows cursor position
-		SDL_GetCursorPos (&cam_mouse);
+	    //get mouse cursor delta
+		CAM_GetScaledMouseDelta (&cam_mouse_x,&cam_mouse_y);
 		//check for X delta values and adjust accordingly
 		//eventually adjust YAW based on amount of movement
 	  //don't do any movement of the cam using YAW/PITCH if we are zooming in/out the camera	
@@ -219,12 +228,12 @@ void EXPORT CAM_Think( void )
 	  {
 		
 		//keep the camera within certain limits around the player (ie avoid certain bad viewing angles)  
-		if (cam_mouse.x>gEngfuncs.GetWindowCenterX())
+		if (cam_mouse_x>0)
 		{
 			//if ((camAngles[YAW]>=225.0)||(camAngles[YAW]<135.0))
 			if (camAngles[YAW]<c_maxyaw->value)
 			{
-				camAngles[ YAW ] += (CAM_ANGLE_MOVE)*((cam_mouse.x-gEngfuncs.GetWindowCenterX())/2);
+				camAngles[ YAW ] += CAM_ANGLE_MOUSEFAC * m_yaw->value * cam_mouse_x;
 			}
 			if (camAngles[YAW]>c_maxyaw->value)
 			{
@@ -232,12 +241,12 @@ void EXPORT CAM_Think( void )
 				camAngles[YAW]=c_maxyaw->value;
 			}
 		}
-		else if (cam_mouse.x<gEngfuncs.GetWindowCenterX())
+		else if (cam_mouse_x<0)
 		{
 			//if ((camAngles[YAW]<=135.0)||(camAngles[YAW]>225.0))
 			if (camAngles[YAW]>c_minyaw->value)
 			{
-			   camAngles[ YAW ] -= (CAM_ANGLE_MOVE)* ((gEngfuncs.GetWindowCenterX()-cam_mouse.x)/2);
+			   camAngles[ YAW ] -= CAM_ANGLE_MOUSEFAC * m_yaw->value * -cam_mouse_x;
 			   	
 			}
 			if (camAngles[YAW]<c_minyaw->value)
@@ -250,43 +259,28 @@ void EXPORT CAM_Think( void )
 		//check for y delta values and adjust accordingly
 		//eventually adjust PITCH based on amount of movement
 		//also make sure camera is within bounds
-		if (cam_mouse.y>gEngfuncs.GetWindowCenterY())
+		if (cam_mouse_y>0)
 		{
 			if(camAngles[PITCH]<c_maxpitch->value)
 			{
-			    camAngles[PITCH] +=(CAM_ANGLE_MOVE)* ((cam_mouse.y-gEngfuncs.GetWindowCenterY())/2);
+			    camAngles[PITCH] += CAM_ANGLE_MOUSEFAC * m_pitch->value * cam_mouse_y;
 			}
 			if (camAngles[PITCH]>c_maxpitch->value)
 			{
 				camAngles[PITCH]=c_maxpitch->value;
 			}
 		}
-		else if (cam_mouse.y<gEngfuncs.GetWindowCenterY())
+		else if (cam_mouse_y<0)
 		{
 			if (camAngles[PITCH]>c_minpitch->value)
 			{
-			   camAngles[PITCH] -= (CAM_ANGLE_MOVE)*((gEngfuncs.GetWindowCenterY()-cam_mouse.y)/2);
+			   camAngles[PITCH] -= CAM_ANGLE_MOUSEFAC * m_pitch->value * -cam_mouse_y;
 			}
 			if (camAngles[PITCH]<c_minpitch->value)
 			{
 				camAngles[PITCH]=c_minpitch->value;
 			}
 		}
-
-		//set old mouse coordinates to current mouse coordinates
-		//since we are done with the mouse
-
-		if ( ( flSensitivity = gHUD.GetSensitivity() ) != 0 )
-		{
-			cam_old_mouse_x=cam_mouse.x*flSensitivity;
-			cam_old_mouse_y=cam_mouse.y*flSensitivity;
-		}
-		else
-		{
-			cam_old_mouse_x=cam_mouse.x;
-			cam_old_mouse_y=cam_mouse.y;
-		}
-		SDL_SetCursorPos (gEngfuncs.GetWindowCenterX(), gEngfuncs.GetWindowCenterY());
 	  }
 	}
 
@@ -318,33 +312,28 @@ void EXPORT CAM_Think( void )
 
 	if (cam_distancemove)
 	{
-		if (cam_mouse.y>gEngfuncs.GetWindowCenterY())
+		if (cam_mouse_y>0)
 		{
 			if(dist<c_maxdistance->value)
 			{
-			    dist +=CAM_DIST_DELTA * ((cam_mouse.y-gEngfuncs.GetWindowCenterY())/2);
+			    dist += CAM_DIST_MOUSEFAC * m_forward->value * cam_mouse_y;
 			}
 			if (dist>c_maxdistance->value)
 			{
 				dist=c_maxdistance->value;
 			}
 		}
-		else if (cam_mouse.y<gEngfuncs.GetWindowCenterY())
+		else if (cam_mouse_y<0)
 		{
 			if (dist>c_mindistance->value)
 			{
-			   dist -= (CAM_DIST_DELTA)*((gEngfuncs.GetWindowCenterY()-cam_mouse.y)/2);
+			   dist -= CAM_DIST_MOUSEFAC * m_forward->value * -cam_mouse_y;
 			}
 			if (dist<c_mindistance->value)
 			{
 				dist=c_mindistance->value;
 			}
 		}
-		//set old mouse coordinates to current mouse coordinates
-		//since we are done with the mouse
-		cam_old_mouse_x=cam_mouse.x*gHUD.GetSensitivity();
-		cam_old_mouse_y=cam_mouse.y*gHUD.GetSensitivity();
-		SDL_SetCursorPos (gEngfuncs.GetWindowCenterX(), gEngfuncs.GetWindowCenterY());
 	}
 #ifdef LATER
 	if( cam_contain->value )
@@ -538,29 +527,14 @@ void CAM_ClearStates( void )
 
 void CAM_StartMouseMove(void)
 {
-	float flSensitivity;
-		
 	//only move the cam with mouse if we are in third person.
 	if (cam_thirdperson)
 	{
-		//set appropriate flags and initialize the old mouse position
-		//variables for mouse camera movement
+		//set appropriate flags
 		if (!cam_mousemove)
 		{
 			cam_mousemove=1;
 			iMouseInUse=1;
-			SDL_GetCursorPos (&cam_mouse);
-
-			if ( ( flSensitivity = gHUD.GetSensitivity() ) != 0 )
-			{
-				cam_old_mouse_x=cam_mouse.x*flSensitivity;
-				cam_old_mouse_y=cam_mouse.y*flSensitivity;
-			}
-			else
-			{
-				cam_old_mouse_x=cam_mouse.x;
-				cam_old_mouse_y=cam_mouse.y;
-			}
 		}
 	}
 	//we are not in 3rd person view..therefore do not allow camera movement
@@ -589,16 +563,12 @@ void CAM_StartDistance(void)
 	//only move the cam with mouse if we are in third person.
 	if (cam_thirdperson)
 	{
-	  //set appropriate flags and initialize the old mouse position
-	  //variables for mouse camera movement
+	  //set appropriate flags
 	  if (!cam_distancemove)
 	  {
 		  cam_distancemove=1;
 		  cam_mousemove=1;
 		  iMouseInUse=1;
-		  SDL_GetCursorPos (&cam_mouse);
-		  cam_old_mouse_x=cam_mouse.x*gHUD.GetSensitivity();
-		  cam_old_mouse_y=cam_mouse.y*gHUD.GetSensitivity();
 	  }
 	}
 	//we are not in 3rd person view..therefore do not allow camera movement
@@ -619,12 +589,12 @@ void CAM_EndDistance(void)
    iMouseInUse=0;
 }
 
-int EXPORT CL_IsThirdPerson( void )
+int CL_DLLEXPORT CL_IsThirdPerson( void )
 {
 	return cam_thirdperson ? 1 : 0;
 }
 
-void EXPORT CL_CameraOffset( float *ofs )
+void CL_DLLEXPORT CL_CameraOffset( float *ofs )
 {
 	VectorCopy( cam_ofs, ofs );
 }

--- a/ricochet/cl_dll/vgui_TeamFortressViewport.cpp
+++ b/ricochet/cl_dll/vgui_TeamFortressViewport.cpp
@@ -56,7 +56,7 @@
 #include "vgui_discobjects.h"
 
 extern WeaponsResource gWR;
-extern int g_iVisibleMouse;
+void IN_SetVisibleMouse(bool visible);
 class CCommandMenu;
 int g_iPlayerClass;
 int g_iTeamNumber;
@@ -1667,7 +1667,7 @@ void TeamFortressViewport::UpdateCursorState()
 	// Need cursor if any VGUI window is up
 	if ( m_pCurrentMenu || m_pServerBrowser->isVisible() || GetClientVoiceMgr()->IsInSquelchMode() )
 	{
-		g_iVisibleMouse = true;
+		IN_SetVisibleMouse(true);
 		App::getInstance()->setCursorOveride( App::getInstance()->getScheme()->getCursor(Scheme::scu_arrow) );
 		return;
 	}
@@ -1676,15 +1676,15 @@ void TeamFortressViewport::UpdateCursorState()
 		// commandmenu doesn't have cursor if hud_capturemouse is turned off
 		if ( gHUD.m_pCvarStealMouse->value != 0.0f )
 		{
-			g_iVisibleMouse = true;
+			IN_SetVisibleMouse(true);
 			App::getInstance()->setCursorOveride( App::getInstance()->getScheme()->getCursor(Scheme::scu_arrow) );
 			return;
 		}
 	}
 
-	IN_ResetMouse();
-	g_iVisibleMouse = false;
 	App::getInstance()->setCursorOveride( App::getInstance()->getScheme()->getCursor(Scheme::scu_none) );
+	IN_SetVisibleMouse(false);
+	IN_ResetMouse();
 }
 
 void TeamFortressViewport::UpdateHighlights()


### PR DESCRIPTION
Fixes ValveSoftware/halflife#1546
- fixed m_rawinput 1 mouse trapped inside a rectangle
- fixed thirdperson camera not working as it should

Fixes ValveSoftware/halflife#1558
- recoded mousethread and made it somewhat useful for very fast mouse
  movements (will reset CursorPos now) and thus also fixed some thread
  synchronization issues (hopefully)

Further fixes:
- Fixed IN_JoyMove doing nothing on Linux for ricochet client
- Limited mouse thread sleep to sane values between 0 and 1000

Does not fix the following:
- Original mouse button down/up reacting when scoreboard mouse is on bugs.
