### PR TITLE
Add build support for OSX 10.9 and make Perforce optional

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -22,6 +22,10 @@ GAMEDB_SRC_DIR=$(COMMON_SRC_DIR)/gamedb
 PUBLIC_SRC_DIR=$(SOURCE_DIR)/public
 DBG_SRC_DIR=$(SOURCE_DIR)/dbg
 
+ifeq ($(PERFORCE), "")
+	PERFORCE=true
+endif
+MAKEENV:=PERFORCE=$(PERFORCE)
 
 BUILD_OBJ_DIR=$(BUILD_DIR)/obj
 
@@ -37,18 +41,21 @@ endif
 ifeq ($(OS),Darwin)
     OSXVER := $(shell sw_vers -productVersion)
 	DEVELOPER_DIR := $(shell /usr/bin/xcode-select -print-path)
-	ifeq (,$(findstring 10.7, $(OSXVER))) 
-		BUILDING_ON_LION := 0
-		COMPILER_BIN_DIR := $(DEVELOPER_DIR)/usr/bin
-		SDK_DIR := $(DEVELOPER_DIR)/SDKs
-	else
-		BUILDING_ON_LION := 1
-		COMPILER_BIN_DIR := $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/bin
-		SDK_DIR := $(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/SDKs
+	COMPILER_BIN_DIR := $(DEVELOPER_DIR)
+	SDK_DIR := $(DEVELOPER_DIR)
+
+	# if not 10.7
+	ifeq (,$(findstring 10.7, $(OSXVER)))
+		COMPILER_BIN_DIR := $(COMPILER_BIN_DIR)/Toolchains/XcodeDefault.xctoolchain
+		SDK_DIR := $(SDK_DIR)/Platforms/MacOSX.platform/Developer
 	endif
 
+	COMPILER_BIN_DIR := $(COMPILER_BIN_DIR)/usr/bin
+	SDK_DIR := $(SDK_DIR)/SDKs
+
 	#SDKROOT ?= $(SDK_DIR)/MacOSX10.6.sdk
-	SDKROOT ?= $(SDK_DIR)/MacOSX10.8.sdk
+	#SDKROOT ?= $(SDK_DIR)/MacOSX10.8.sdk
+	SDKROOT ?= $(SDK_DIR)/MacOSX10.9.sdk
 
 	ARCH_FLAGS ?= -arch i386 -m32 -march=prescott -gdwarf-2 -g2  -Wno-typedef-redefinition -momit-leaf-frame-pointer -mtune=core2
 	CPP_LIB=-lstdc++ -lpthread
@@ -118,12 +125,12 @@ AR=ar
 LIBEXT=a
 MAKE+= -j8
 
-MAKE_HL_LIB=$(MAKE) -f Makefile.hldll
-MAKE_DMC_LIB=$(MAKE) -f Makefile.dmcdll
-MAKE_RICOCHET_LIB=$(MAKE) -f Makefile.ricochetdll
-MAKE_HL_CDLL=$(MAKE) -f Makefile.hl_cdll
-MAKE_DMC_CDLL=$(MAKE) -f Makefile.dmc_cdll
-MAKE_RICOCHET_CDLL=$(MAKE) -f Makefile.ricochet_cdll
+MAKE_HL_LIB=$(MAKEENV) $(MAKE) -f Makefile.hldll
+MAKE_DMC_LIB=$(MAKEENV) $(MAKE) -f Makefile.dmcdll
+MAKE_RICOCHET_LIB=$(MAKEENV) $(MAKE) -f Makefile.ricochetdll
+MAKE_HL_CDLL=$(MAKEENV) $(MAKE) -f Makefile.hl_cdll
+MAKE_DMC_CDLL=$(MAKEENV) $(MAKE) -f Makefile.dmc_cdll
+MAKE_RICOCHET_CDLL=$(MAKEENV) $(MAKE) -f Makefile.ricochet_cdll
 
 #############################################################################
 # SETUP AND BUILD

--- a/linux/Makefile.dmc_cdll
+++ b/linux/Makefile.dmc_cdll
@@ -115,7 +115,9 @@ all: client_dmc.$(SHLIBEXT)
 
 client_dmc.$(SHLIBEXT): $(DMC_OBJS) $(PUBLIC_OBJS) $(COMMON_OBJS) $(GAME_SHARED_OBJS) $(PM_SHARED_OBJS)
 	$(CLINK) -o $(BUILD_DIR)/$@ $(DMC_OBJS) $(PUBLIC_OBJS) $(COMMON_OBJS) $(GAME_SHARED_OBJS) $(PM_SHARED_OBJS) $(LDFLAGS) $(CPP_LIB)
+ifeq ($(PERFORCE), true)
 	p4 edit ../../game/mod/cl_dlls/client.$(SHLIBEXT)
+endif
 	cp $(BUILD_DIR)/$@  ../../game/mod/cl_dlls/client.$(SHLIBEXT)
 	./gendbg.sh ../../game/mod/cl_dlls/client.$(SHLIBEXT)
 

--- a/linux/Makefile.dmcdll
+++ b/linux/Makefile.dmcdll
@@ -93,7 +93,9 @@ dirs:
 
 dmc.$(SHLIBEXT): $(DMCDLL_OBJS) $(PM_OBJS) $(GAME_SHARED_OBJS)
 	$(CLINK) $(SHLIBLDFLAGS) -o $(BUILD_DIR)/$@ $(DMCDLL_OBJS) $(PM_OBJS) $(GAME_SHARED_OBJS) $(LDFLAGS) $(CPP_LIB)
+ifeq ($(PERFORCE), true)
 	p4 edit ../../game/mod/dlls/$@
+endif
 	cp $(BUILD_DIR)/$@  ../../game/mod/dlls
 	./gendbg.sh ../../game/mod/dlls/dmc.$(SHLIBEXT)
 		

--- a/linux/Makefile.hl_cdll
+++ b/linux/Makefile.hl_cdll
@@ -137,7 +137,9 @@ all: client.$(SHLIBEXT)
 
 client.$(SHLIBEXT): $(HL1_OBJS) $(PUBLIC_OBJS) $(COMMON_OBJS) $(GAME_SHARED_OBJS) $(DLL_OBJS) $(PM_SHARED_OBJS)
 	$(CLINK) -o $(BUILD_DIR)/$@ $(HL1_OBJS) $(PUBLIC_OBJS) $(COMMON_OBJS) $(GAME_SHARED_OBJS) $(DLL_OBJS) $(PM_SHARED_OBJS) $(LDFLAGS) $(CPP_LIB)
+ifeq ($(PERFORCE), true)
 	p4 edit ../../game/mod/cl_dlls/$@
+endif
 	cp $(BUILD_DIR)/$@  ../../game/mod/cl_dlls
 	./gendbg.sh ../../game/mod/cl_dlls/client.$(SHLIBEXT)
 

--- a/linux/Makefile.hldll
+++ b/linux/Makefile.hldll
@@ -151,7 +151,9 @@ dirs:
 
 hl.$(SHLIBEXT): $(HLDLL_OBJS) $(HLWPN_OBJS) $(PM_OBJS) $(GAME_SHARED_OBJS)
 	$(CC) $(LDFLAGS) $(SHLIBLDFLAGS) -o $(BUILD_DIR)/$@ $(HLDLL_OBJS) $(HLWPN_OBJS) $(PM_OBJS) $(GAME_SHARED_OBJS)
+ifeq ($(PERFORCE), true)
 	p4 edit ../../game/mod/dlls/hl.$(SHLIBEXT)
+endif
 	cp $(BUILD_DIR)/$@  ../../game/mod/dlls/hl.$(SHLIBEXT)
 	./gendbg.sh ../../game/mod/dlls/hl.$(SHLIBEXT)
 	

--- a/linux/Makefile.ricochet_cdll
+++ b/linux/Makefile.ricochet_cdll
@@ -114,7 +114,9 @@ all: client_ricochet.$(SHLIBEXT)
 
 client_ricochet.$(SHLIBEXT): $(RICOCHET_OBJS) $(PUBLIC_OBJS) $(COMMON_OBJS) $(GAME_SHARED_OBJS) $(PM_SHARED_OBJS)
 	$(CLINK) -o $(BUILD_DIR)/$@ $(RICOCHET_OBJS) $(PUBLIC_OBJS) $(COMMON_OBJS) $(GAME_SHARED_OBJS) $(PM_SHARED_OBJS) $(LDFLAGS)  $(CPP_LIB)
+ifeq ($(PERFORCE), true)
 	p4 edit ../../game/mod/cl_dlls/client.$(SHLIBEXT)
+endif
 	cp $(BUILD_DIR)/$@  ../../game/mod/cl_dlls/client.$(SHLIBEXT)
 	./gendbg.sh ../../game/mod/cl_dlls/client.$(SHLIBEXT)		
 

--- a/linux/Makefile.ricochetdll
+++ b/linux/Makefile.ricochetdll
@@ -102,7 +102,9 @@ dirs:
 
 ricochet.$(SHLIBEXT): $(RICOCHETDLL_OBJS) $(RICOCHETWPN_OBJS) $(PM_OBJS) $(GAME_SHARED_OBJS)
 	$(CLINK) $(SHLIBLDFLAGS) -o $(BUILD_DIR)/$@ $(RICOCHETDLL_OBJS) $(RICOCHETWPN_OBJS) $(PM_OBJS) $(GAME_SHARED_OBJS) $(LDFLAGS) $(CPP_LIB)
+ifeq ($(PERFORCE), true)
 	p4 edit ../../game/mod/dlls/$@
+endif
 	cp $(BUILD_DIR)/$@  ../../game/mod/dlls
 	./gendbg.sh ../../game/mod/dlls/$@
 		

--- a/linux/gendbg.sh
+++ b/linux/gendbg.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 
+if [ -z "$PERFORCE" ]; then
+	PERFORCE=true
+fi
+
 UNAME=`uname`
 if [ "$UNAME" == "Darwin" ]; then
-	p4 edit $1.dSYM/...
+	if [ "$PERFORCE" == true ]; then
+		p4 edit $1.dSYM/...
+	fi
 	dsymutil $1
-	p4 revert -a $1.dSYM/...
+	if [ "$PERFORCE" == true ]; then
+		p4 revert -a $1.dSYM/...
+	fi
 	exit 0;
 fi
 


### PR DESCRIPTION
This PR adds support for compiling on OS X 10.9.

It also makes compiling with Perforce on Linux/OSX optional. This is because lots of people don't have the exact Perforce setup required for those commands to work – or don't want to worry setting up that sort of a server when they just use Git for their version control.

By default, it'll execute the Perforce commands as normal. However, if you call make with the `PERFORCE` environment variable set to `false`, it'll ignore those commands. Makes everything nicer because you don't need to see a bunch of unnecessary Perforce client errors every compile.

eg: `PERFORCE=false make`

If you don't want the Perforce changes and just want the OSX 10.9 support, let me know and I can just split out the 10.9 support to its own PR.
