### PR TITLE
Make zombie pitches more uniform, fix unused variable

### DIFF
--- a/dlls/zombie.cpp
+++ b/dlls/zombie.cpp
@@ -169,16 +169,18 @@ void CZombie :: AlertSound( void )
 
 void CZombie :: IdleSound( void )
 {
-	int pitch = 95 + RANDOM_LONG(0,9);
+	int pitch = 100 + RANDOM_LONG(-5,5);
 
 	// Play a random idle sound
-	EMIT_SOUND_DYN ( ENT(pev), CHAN_VOICE, pIdleSounds[ RANDOM_LONG(0,ARRAYSIZE(pIdleSounds)-1) ], 1.0, ATTN_NORM, 0, 100 + RANDOM_LONG(-5,5) );
+	EMIT_SOUND_DYN ( ENT(pev), CHAN_VOICE, pIdleSounds[ RANDOM_LONG(0,ARRAYSIZE(pIdleSounds)-1) ], 1.0, ATTN_NORM, 0, pitch );
 }
 
 void CZombie :: AttackSound( void )
 {
+	int pitch = 100 + RANDOM_LONG(-5,5);
+
 	// Play a random attack sound
-	EMIT_SOUND_DYN ( ENT(pev), CHAN_VOICE, pAttackSounds[ RANDOM_LONG(0,ARRAYSIZE(pAttackSounds)-1) ], 1.0, ATTN_NORM, 0, 100 + RANDOM_LONG(-5,5) );
+	EMIT_SOUND_DYN ( ENT(pev), CHAN_VOICE, pAttackSounds[ RANDOM_LONG(0,ARRAYSIZE(pAttackSounds)-1) ], 1.0, ATTN_NORM, 0, pitch );
 }
 
 


### PR DESCRIPTION
This just fixes an unused variable, and makes all of the zombie's sound functions use the pitch variable.

Small change, but makes for more self-documenting and more uniform code.
