### PR TITLE
Hornet Loading Transition Crash

### DIFF
--- a/dlls/hornet.cpp
+++ b/dlls/hornet.cpp
@@ -397,7 +397,7 @@ void CHornet::DartTouch( CBaseEntity *pOther )
 
 void CHornet::DieTouch ( CBaseEntity *pOther )
 {
-	if ( pOther && pOther->pev->takedamage )
+	if ( pOther && pOther->pev->takedamage && pev->owner )
 	{// do the damage
 
 		switch (RANDOM_LONG(0,2))


### PR DESCRIPTION
Because that pev->owner isn't being checked it will cause the game to
crash when a hornet hits you after a loading transition.