### PR TITLE
Fix a crash when a falling item is picked up by a player.

### DIFF
--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -627,7 +627,8 @@ void CBasePlayerItem::DefaultTouch( CBaseEntity *pOther )
 	// then after the item touches the ground its Touch will be set back to DefaultTouch,
 	// so the player will pick it up again, this time Kill-ing the item (since we already have it in the inventory),
 	// which will make the pointer bad and crash the game.
-	SetThink( NULL );
+	if (m_pfnThink == &CBasePlayerItem::FallThink)
+		SetThink( NULL );
 }
 
 BOOL CanAttack( float attack_time, float curtime, BOOL isPredicted )

--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -622,6 +622,12 @@ void CBasePlayerItem::DefaultTouch( CBaseEntity *pOther )
 	}
 
 	SUB_UseTargets( pOther, USE_TOGGLE, 0 ); // UNDONE: when should this happen?
+
+	// If the item is falling and its Think remains FallItem after the player picks it up,
+	// then after the item touches the ground its Touch will be set back to DefaultTouch,
+	// so the player will pick it up again, this time Kill-ing the item (since we already have it in the inventory),
+	// which will make the pointer bad and crash the game.
+	SetThink( NULL );
 }
 
 BOOL CanAttack( float attack_time, float curtime, BOOL isPredicted )


### PR DESCRIPTION
How to reproduce:
1. Break a box that contains an item which will spawn above the ground.
2. Pick the item up while it's still in the air.

Here's a convenivent save file: http://www.mediafire.com/download/9sgnzrswgfqv63w/dropbug.sav
Load it and fire the shotgun secondary fire, the game should crash.

Copy of the comment:

	// If the item is falling and its Think remains FallItem after the player picks it up,
	// then after the item touches the ground its Touch will be set back to DefaultTouch,
	// so the player will pick it up again, this time Kill-ing the item (since we already have it in the inventory),
	// which will make the pointer bad and crash the game.