### PR TITLE
Fix the crowbar damage always being calculated halved.

### DIFF
--- a/dlls/crowbar.cpp
+++ b/dlls/crowbar.cpp
@@ -232,7 +232,14 @@ int CCrowbar::Swing( int fFirst )
 
 		ClearMultiDamage( );
 
-		if ( (m_flNextPrimaryAttack + 1 < UTIL_WeaponTimeBase() ) || g_pGameRules->IsMultiplayer() )
+		// If building with the clientside weapon prediction system,
+		// UTIL_WeaponTimeBase() is always 0 and m_flNextPrimaryAttack is >= -1.0f, thus making
+		// m_flNextPrimaryAttack + 1 < UTIL_WeaponTimeBase() always evaluate to false.
+		if ( (m_flNextPrimaryAttack + 1 < UTIL_WeaponTimeBase() ) || g_pGameRules->IsMultiplayer()
+#ifdef CLIENT_WEAPONS
+			|| m_flNextPrimaryAttack == -1.0f
+#endif
+			)
 		{
 			// first swing does full damage
 			pEntity->TraceAttack(m_pPlayer->pev, gSkillData.plrDmgCrowbar, gpGlobals->v_forward, &tr, DMG_CLUB ); 


### PR DESCRIPTION
...as opposed to the first hit dealing the full damage and the subsequent hits - halved.

If the DLLs are built with the clientside weapon prediction system, the condition for detecting the first hit always evaluates to false, so an extra check is added specifically for this condition.

How to check / reproduce:
1. Load the `c1a1` map. Run into the next room, past the lasers and pick up the crowbar.
2. Hit a window in the door once.
- Expected behaviour: the window breaks from the first hit, as it was before the weapon prediction system.
- Current behaviour (without this fix): the window doesn't break because the first hit is not doing the halved damage it supposed to do thus making the damage not enough to break the window.