### PR TITLE
Implement a CVar for toggling the bunnyhop cap.

### DIFF
--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -280,6 +280,17 @@ int __MsgFunc_AllowSpec(const char *pszName, int iSize, void *pbuf)
 	return 0;
 }
 
+extern "C" int g_bhopcap;
+
+int __MsgFunc_Bhopcap(const char *pszName, int iSize, void *pbuf)
+{
+	BEGIN_READ( pbuf, iSize );
+
+	g_bhopcap = READ_BYTE();
+
+	return 1;
+}
+
 // This is called every time the DLL is loaded
 void CHud :: Init( void )
 {
@@ -318,6 +329,9 @@ void CHud :: Init( void )
 
 	// VGUI Menus
 	HOOK_MESSAGE( VGUIMenu );
+
+	// Bunnyhop cap
+	HOOK_MESSAGE( Bhopcap );
 
 	CVAR_CREATE( "hud_classautokill", "1", FCVAR_ARCHIVE | FCVAR_USERINFO );		// controls whether or not to suicide immediately on TF class switch
 	CVAR_CREATE( "hud_takesshots", "0", FCVAR_ARCHIVE );		// controls whether or not to automatically take screenshots at the end of a round

--- a/dlls/game.cpp
+++ b/dlls/game.cpp
@@ -38,6 +38,7 @@ cvar_t	teamlist = {"mp_teamlist","hgrunt;scientist", FCVAR_SERVER };
 cvar_t	teamoverride = {"mp_teamoverride","1" };
 cvar_t	defaultteam = {"mp_defaultteam","0" };
 cvar_t	allowmonsters={"mp_allowmonsters","0", FCVAR_SERVER };
+cvar_t	bhopcap = {"mp_bhopcap","1", FCVAR_SERVER };
 
 cvar_t  allow_spectators = { "allow_spectators", "0.0", FCVAR_SERVER };		// 0 prevents players from being spectators
 
@@ -481,6 +482,7 @@ void GameDLLInit( void )
 	CVAR_REGISTER (&teamoverride);
 	CVAR_REGISTER (&defaultteam);
 	CVAR_REGISTER (&allowmonsters);
+	CVAR_REGISTER (&bhopcap);
 
 	CVAR_REGISTER (&mp_chattime);
 

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -39,6 +39,10 @@ extern int gmsgScoreInfo;
 extern int gmsgMOTD;
 extern int gmsgServerName;
 
+extern int gmsgBhopcap;
+extern "C" int g_bhopcap;
+extern cvar_t bhopcap;
+
 extern int g_teamplay;
 
 #define ITEM_RESPAWN_TIME	30
@@ -266,6 +270,16 @@ void CHalfLifeMultiplay :: Think ( void )
 
 	last_frags = frags_remaining;
 	last_time  = time_remaining;
+
+	// Update the bunnyhop cap
+	int old_bhopcap = g_bhopcap;
+	g_bhopcap = (bhopcap.value != 0.);
+	if (g_bhopcap != old_bhopcap)
+	{
+		MESSAGE_BEGIN( MSG_ALL, gmsgBhopcap, NULL );
+			WRITE_BYTE( g_bhopcap );
+		MESSAGE_END();
+	}
 }
 
 

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -45,6 +45,7 @@ extern DLL_GLOBAL	BOOL	g_fDrawLines;
 int gEvilImpulse101;
 extern DLL_GLOBAL int		g_iSkillLevel, gDisplayTitle;
 
+extern "C" int g_bhopcap;
 
 BOOL gInitHUD = TRUE;
 
@@ -184,6 +185,7 @@ int gmsgSetFOV = 0;
 int gmsgShowMenu = 0;
 int gmsgGeigerRange = 0;
 int gmsgTeamNames = 0;
+int gmsgBhopcap = 0;
 
 int gmsgStatusText = 0;
 int gmsgStatusValue = 0; 
@@ -232,6 +234,7 @@ void LinkUserMessages( void )
 	gmsgFade = REG_USER_MSG("ScreenFade", sizeof(ScreenFade));
 	gmsgAmmoX = REG_USER_MSG("AmmoX", 2);
 	gmsgTeamNames = REG_USER_MSG( "TeamNames", -1 );
+	gmsgBhopcap = REG_USER_MSG( "Bhopcap", 1 );
 
 	gmsgStatusText = REG_USER_MSG("StatusText", -1);
 	gmsgStatusValue = REG_USER_MSG("StatusValue", 3); 
@@ -3971,6 +3974,10 @@ void CBasePlayer :: UpdateClientData( void )
 			{
 				FireTargets( "game_playerjoin", this, this, USE_TOGGLE, 0 );
 			}
+
+			MESSAGE_BEGIN( MSG_ONE, gmsgBhopcap, NULL, pev );
+				WRITE_BYTE( g_bhopcap );
+			MESSAGE_END();
 		}
 
 		FireTargets( "game_playerspawn", this, this, USE_TOGGLE, 0 );

--- a/dlls/singleplay_gamerules.cpp
+++ b/dlls/singleplay_gamerules.cpp
@@ -30,11 +30,15 @@ extern int gmsgDeathMsg;	// client dll messages
 extern int gmsgScoreInfo;
 extern int gmsgMOTD;
 
+extern "C" int g_bhopcap;
+
 //=========================================================
 //=========================================================
 CHalfLifeRules::CHalfLifeRules( void )
 {
 	RefreshSkillData();
+
+	g_bhopcap = 0;
 }
 
 //=========================================================

--- a/pm_shared/pm_shared.c
+++ b/pm_shared/pm_shared.c
@@ -152,6 +152,7 @@ static char grgszTextureName[CTEXTURESMAX][CBTEXTURENAMEMAX];
 static char grgchTextureType[CTEXTURESMAX];
 
 int g_onladder = 0;
+int g_bhopcap = 1;
 
 void PM_SwapTextures( int i, int j )
 {
@@ -2555,7 +2556,8 @@ void PM_Jump (void)
 	// In the air now.
     pmove->onground = -1;
 
-	PM_PreventMegaBunnyJumping();
+	if (g_bhopcap)
+		PM_PreventMegaBunnyJumping();
 
 	if ( tfc )
 	{


### PR DESCRIPTION
Implement a serverside CVar `mp_bhopcap` which controls the presence of the bunnyhop cap and defaults to 1 (bunnyhop cap enabled) so that no existing server setups have anything changed on update. If set to 0, the bunnyhop cap will be disabled. In singleplayer the bunnyhop cap is always disabled because it has no use there and in no way affects the casual gamers.

Right now many server admins who chose to remove the bunnyhop cap have to do it through the use of specialized server plugins which isn't an optimal solution since the clients get the "Bunnyhop cap lag" (the clientside prediction always assumes that the cap is present and reacts accordingly) which is very annoying to say the least.

In this pull request the value of `mp_bhopcap` is sent to clients so the clientside prediction can take the presence or absence of the bunnyhop cap into account.

We started a [petition](https://www.change.org/p/alfred-reynolds-valve-software-implement-a-bunnyhop-cap-variable) to gather support for this feature to be implemented (or this pull request accepted).
