### PR TITLE
Add call to TabulateAmmo Resolves #1707

### DIFF
--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -3056,6 +3056,9 @@ int CBasePlayer::Restore( CRestore &restore )
 
 	RenewItems();
 
+	//Resync ammo data so you can reload - Solokiller
+	TabulateAmmo();
+
 #if defined( CLIENT_WEAPONS )
 	// HACK:	This variable is saved/restored in CBaseMonster as a time variable, but we're using it
 	//			as just a counter.  Ideally, this needs its own variable that's saved as a plain float.


### PR DESCRIPTION
This fixes issue #1707 
Loading a saved game where the active item has a partially empty clip wouldn't allow you to reload. This pull request fixes that by adding a call to TabulateAmmo, which resyncs ammo data.
