### PR TITLE
Fix GetHullBounds & HUD_GetHullBounds assignment

### DIFF
--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -75,21 +75,24 @@ int CL_DLLEXPORT HUD_GetHullBounds( int hullnumber, float *mins, float *maxs )
 
 	int iret = 0;
 
+	Vector& vecMins = *reinterpret_cast<Vector*>( mins );
+	Vector& vecMaxs = *reinterpret_cast<Vector*>( maxs );
+
 	switch ( hullnumber )
 	{
 	case 0:				// Normal player
-		mins = Vector(-16, -16, -36);
-		maxs = Vector(16, 16, 36);
+		vecMins = Vector( -16, -16, -36 );
+		vecMaxs = Vector( 16, 16, 36 );
 		iret = 1;
 		break;
 	case 1:				// Crouched player
-		mins = Vector(-16, -16, -18 );
-		maxs = Vector(16, 16, 18 );
+		vecMins = Vector( -16, -16, -18 );
+		vecMaxs = Vector( 16, 16, 18 );
 		iret = 1;
 		break;
 	case 2:				// Point based hull
-		mins = Vector( 0, 0, 0 );
-		maxs = Vector( 0, 0, 0 );
+		vecMins = Vector( 0, 0, 0 );
+		vecMaxs = Vector( 0, 0, 0 );
 		iret = 1;
 		break;
 	}

--- a/dlls/client.cpp
+++ b/dlls/client.cpp
@@ -1843,21 +1843,24 @@ int GetHullBounds( int hullnumber, float *mins, float *maxs )
 {
 	int iret = 0;
 
+	Vector& vecMins = *reinterpret_cast<Vector*>( mins );
+	Vector& vecMaxs = *reinterpret_cast<Vector*>( maxs );
+
 	switch ( hullnumber )
 	{
 	case 0:				// Normal player
-		mins = VEC_HULL_MIN;
-		maxs = VEC_HULL_MAX;
+		vecMins = VEC_HULL_MIN;
+		vecMaxs = VEC_HULL_MAX;
 		iret = 1;
 		break;
 	case 1:				// Crouched player
-		mins = VEC_DUCK_HULL_MIN;
-		maxs = VEC_DUCK_HULL_MAX;
+		vecMins = VEC_DUCK_HULL_MIN;
+		vecMaxs = VEC_DUCK_HULL_MAX;
 		iret = 1;
 		break;
 	case 2:				// Point based hull
-		mins = Vector( 0, 0, 0 );
-		maxs = Vector( 0, 0, 0 );
+		vecMins = Vector( 0, 0, 0 );
+		vecMaxs = Vector( 0, 0, 0 );
 		iret = 1;
 		break;
 	}

--- a/dmc/cl_dll/cdll_int.cpp
+++ b/dmc/cl_dll/cdll_int.cpp
@@ -93,21 +93,24 @@ int EXPORT HUD_GetHullBounds( int hullnumber, float *mins, float *maxs )
 {
 	int iret = 0;
 
+	Vector& vecMins = *reinterpret_cast<Vector*>( mins );
+	Vector& vecMaxs = *reinterpret_cast<Vector*>( maxs );
+
 	switch ( hullnumber )
 	{
 	case 0:				// Normal player
-		mins = Vector(-16, -16, -32);
-		maxs = Vector(16, 16, 32);
+		vecMins = Vector( -16, -16, -32 );
+		vecMaxs = Vector( 16, 16, 32 );
 		iret = 1;
 		break;
 	case 1:				// Crouched player
-		mins = Vector(-16, -16, -32);
-		maxs = Vector(16, 16, 32);
+		vecMins = Vector( -16, -16, -32 );
+		vecMaxs = Vector( 16, 16, 32 );
 		iret = 1;
 		break;
 	case 2:				// Point based hull
-		mins = Vector( 0, 0, 0 );
-		maxs = Vector( 0, 0, 0 );
+		vecMins = Vector( 0, 0, 0 );
+		vecMaxs = Vector( 0, 0, 0 );
 		iret = 1;
 		break;
 	}

--- a/dmc/dlls/client.cpp
+++ b/dmc/dlls/client.cpp
@@ -1734,21 +1734,24 @@ int GetHullBounds( int hullnumber, float *mins, float *maxs )
 {
 	int iret = 0;
 
+	Vector& vecMins = *reinterpret_cast<Vector*>( mins );
+	Vector& vecMaxs = *reinterpret_cast<Vector*>( maxs );
+
 	switch ( hullnumber )
 	{
 	case 0:				// Normal player
-		mins = Vector(-16, -16, -32);
-		maxs = Vector(16, 16, 32);
+		vecMins = Vector( -16, -16, -32 );
+		vecMaxs = Vector( 16, 16, 32 );
 		iret = 1;
 		break;
 	case 1:				// Crouched player
-		mins = Vector(-16, -16, -32);
-		maxs = Vector(16, 16, 32);
+		vecMins = Vector( -16, -16, -32 );
+		vecMaxs = Vector( 16, 16, 32 );
 		iret = 1;
 		break;
 	case 2:				// Point based hull
-		mins = Vector( 0, 0, 0 );
-		maxs = Vector( 0, 0, 0 );
+		vecMins = Vector( 0, 0, 0 );
+		vecMaxs = Vector( 0, 0, 0 );
 		iret = 1;
 		break;
 	}

--- a/ricochet/cl_dll/cdll_int.cpp
+++ b/ricochet/cl_dll/cdll_int.cpp
@@ -81,21 +81,24 @@ int EXPORT HUD_GetHullBounds( int hullnumber, float *mins, float *maxs )
 {
 	int iret = 0;
 
+	Vector& vecMins = *reinterpret_cast<Vector*>( mins );
+	Vector& vecMaxs = *reinterpret_cast<Vector*>( maxs );
+
 	switch ( hullnumber )
 	{
 	case 0:				// Normal player
-		mins = Vector(-16, -16, -36);
-		maxs = Vector(16, 16, 36);
+		vecMins = Vector( -16, -16, -36 );
+		vecMaxs = Vector( 16, 16, 36 );
 		iret = 1;
 		break;
 	case 1:				// Crouched player
-		mins = Vector(-16, -16, -18 );
-		maxs = Vector(16, 16, 18 );
+		vecMins = Vector( -16, -16, -18 );
+		vecMaxs = Vector( 16, 16, 18 );
 		iret = 1;
 		break;
 	case 2:				// Point based hull
-		mins = Vector( 0, 0, 0 );
-		maxs = Vector( 0, 0, 0 );
+		vecMins = Vector( 0, 0, 0 );
+		vecMaxs = Vector( 0, 0, 0 );
 		iret = 1;
 		break;
 	}

--- a/ricochet/dlls/client.cpp
+++ b/ricochet/dlls/client.cpp
@@ -1703,21 +1703,24 @@ int GetHullBounds( int hullnumber, float *mins, float *maxs )
 {
 	int iret = 0;
 
+	Vector& vecMins = *reinterpret_cast<Vector*>( mins );
+	Vector& vecMaxs = *reinterpret_cast<Vector*>( maxs );
+
 	switch ( hullnumber )
 	{
 	case 0:				// Normal player
-		mins = VEC_HULL_MIN;
-		maxs = VEC_HULL_MAX;
+		vecMins = VEC_HULL_MIN;
+		vecMaxs = VEC_HULL_MAX;
 		iret = 1;
 		break;
 	case 1:				// Crouched player
-		mins = VEC_DUCK_HULL_MIN;
-		maxs = VEC_DUCK_HULL_MAX;
+		vecMins = VEC_DUCK_HULL_MIN;
+		vecMaxs = VEC_DUCK_HULL_MAX;
 		iret = 1;
 		break;
 	case 2:				// Point based hull
-		mins = Vector( 0, 0, 0 );
-		maxs = Vector( 0, 0, 0 );
+		vecMins = Vector( 0, 0, 0 );
+		vecMaxs = Vector( 0, 0, 0 );
 		iret = 1;
 		break;
 	}


### PR DESCRIPTION
Fixed GetHullBounds and HUD_GetHullBounds assigning bounds incorrectly.
Assigning vectors to float pointers does nothing useful.
I didn't test the DMC and Ricochet changes, but they're identical to the
Half-Life versions, so they should be fine.
Resolves #1703
