### PR TITLE
Visual Studio 2015 and later Compatibility Support

### DIFF
--- a/cl_dll/util_vector.h
+++ b/cl_dll/util_vector.h
@@ -19,7 +19,11 @@
 // Misc C-runtime library headers
 #include "stdio.h"
 #include "stdlib.h"
+#if _MSC_VER >= 1900 // C++11 Compatible for Visual Studio 2015 and later.
+#include <cmath>
+#else
 #include "math.h"
+#endif
 
 // Header file containing definition of globalvars_t and entvars_t
 typedef unsigned int	func_t;		//

--- a/dlls/extdll.h
+++ b/dlls/extdll.h
@@ -66,7 +66,11 @@ typedef int BOOL;
 // Misc C-runtime library headers
 #include "stdio.h"
 #include "stdlib.h"
+#if _MSC_VER >= 1900 // C++11 Compatible for Visual Studio 2015 and later.
+#include <cmath>
+#else
 #include "math.h"
+#endif
 
 // Header file containing definition of globalvars_t and entvars_t
 typedef unsigned int func_t;					//

--- a/dmc/cl_dll/util_vector.h
+++ b/dmc/cl_dll/util_vector.h
@@ -19,7 +19,11 @@
 // Misc C-runtime library headers
 #include "stdio.h"
 #include "stdlib.h"
+#if _MSC_VER >= 1900 // C++11 Compatible for Visual Studio 2015 and later.
+#include <cmath>
+#else
 #include "math.h"
+#endif
 
 // Header file containing definition of globalvars_t and entvars_t
 typedef unsigned int	func_t;					//

--- a/dmc/dlls/extdll.h
+++ b/dmc/dlls/extdll.h
@@ -74,7 +74,11 @@ typedef int BOOL;
 // Misc C-runtime library headers
 #include "stdio.h"
 #include "stdlib.h"
+#if _MSC_VER >= 1900 // C++11 Compatible for Visual Studio 2015 and later.
+#include <cmath>
+#else
 #include "math.h"
+#endif
 
 // Header file containing definition of globalvars_t and entvars_t
 typedef unsigned int	func_t;					//

--- a/ricochet/cl_dll/util_vector.h
+++ b/ricochet/cl_dll/util_vector.h
@@ -19,7 +19,11 @@
 // Misc C-runtime library headers
 #include "stdio.h"
 #include "stdlib.h"
+#if _MSC_VER >= 1900 // C++11 Compatible for Visual Studio 2015 and later.
+#include <cmath>
+#else
 #include "math.h"
+#endif
 
 // Header file containing definition of globalvars_t and entvars_t
 typedef unsigned int	func_t;					//

--- a/ricochet/dlls/extdll.h
+++ b/ricochet/dlls/extdll.h
@@ -74,7 +74,11 @@ typedef int BOOL;
 // Misc C-runtime library headers
 #include "stdio.h"
 #include "stdlib.h"
+#ifdef _MSC_VER >= 1900 // C++11 Compatible for Visual Studio 2015 and later.
+#include <cmath>
+#else
 #include "math.h"
+#endif
 
 // Header file containing definition of globalvars_t and entvars_t
 typedef unsigned int	func_t;					//


### PR DESCRIPTION
Checks were added due to Visual Studio 2015 adding extended C++11
math support.  Defines were added to ensure backwards compatibility.