### PR TITLE
Addresses ValveSoftware/halflife#1622

### DIFF
--- a/dmc/dlls/sound.cpp
+++ b/dmc/dlls/sound.cpp
@@ -1539,7 +1539,7 @@ void TEXTURETYPE_Init()
 	char buffer[512];
 	int i, j;
 	byte *pMemFile;
-	int fileSize, filePos;
+	int fileSize, filePos = 0;
 
 	if (fTextureTypeInit)
 		return;

--- a/ricochet/dlls/sound.cpp
+++ b/ricochet/dlls/sound.cpp
@@ -1544,7 +1544,7 @@ void TEXTURETYPE_Init()
 	char buffer[512];
 	int i, j;
 	byte *pMemFile;
-	int fileSize, filePos;
+	int fileSize, filePos = 0;
 
 	if (fTextureTypeInit)
 		return;


### PR DESCRIPTION
Fixes crashes in sound.cpp for dmc and ricochet mods.