### PR TITLE
Update to triggers to take into account usetype

### DIFF
--- a/dlls/triggers.cpp
+++ b/dlls/triggers.cpp
@@ -896,18 +896,33 @@ void CTriggerHurt :: RadiationThink( void )
 //
 void CBaseTrigger :: ToggleUse ( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value )
 {
-	if (pev->solid == SOLID_NOT)
-	{// if the trigger is off, turn it on
+	switch (useType){
+	case 1: //Enable
 		pev->solid = SOLID_TRIGGER;
-		
 		// Force retouch
 		gpGlobals->force_retouch++;
-	}
-	else
-	{// turn the trigger off
+		break;
+
+	case 0: //Disable
 		pev->solid = SOLID_NOT;
+		break;
+
+	default: //Toggle
+		if (pev->solid == SOLID_NOT)
+		{// if the trigger is off, turn it on
+			pev->solid = SOLID_TRIGGER;
+
+			// Force retouch
+			gpGlobals->force_retouch++;
+		}
+		else
+		{// turn the trigger off
+			pev->solid = SOLID_NOT;
+		}
+		break;
 	}
 	UTIL_SetOrigin( pev, pev->origin );
+
 }
 
 // When touched, a hurt trigger does DMG points of damage each half-second


### PR DESCRIPTION
When a trigger is set to an input, it only toggles on and off regardless of what the actual input's usetype is. I've fixed this so it can be turned on, turned off, or toggled like most other entities.

This is mainly for mods, as I don't think it affects anything in the main game.