### PR TITLE
Fix houndeyes behaviour

### DIFF
--- a/dlls/houndeye.cpp
+++ b/dlls/houndeye.cpp
@@ -35,7 +35,7 @@ extern CGraph WorldGraph;
 #define	HOUNDEYE_MAX_ATTACK_RADIUS		384
 #define	HOUNDEYE_SQUAD_BONUS			(float)1.1
 
-#define HOUNDEYE_EYE_FRAMES 4 // how many different switchable maps for the eye
+#define HOUNDEYE_EYE_FRAMES 3 // how many different switchable maps for the eye
 
 #define HOUNDEYE_SOUND_STARTLE_VOLUME	128 // how loud a sound has to be to badly scare a sleeping houndeye
 
@@ -794,6 +794,10 @@ void CHoundeye :: RunTask ( Task_t *pTask )
 			{
 				pev->skin++;
 			}
+			else
+			{
+				TaskComplete();
+			}
 			break;
 		}
 	case TASK_HOUND_HOP_BACK:
@@ -961,6 +965,7 @@ Task_t	tlHoundSleep[] =
 	{ TASK_HOUND_FALL_ASLEEP,	(float)0				},
 	{ TASK_WAIT_RANDOM,			(float)25				},
 	{ TASK_HOUND_CLOSE_EYE,		(float)0				},
+	{ TASK_WAIT_INDEFINITE,		(float)0				},
 	//{ TASK_WAIT,				(float)10				},
 	//{ TASK_WAIT_RANDOM,			(float)10				},
 };

--- a/dlls/houndeye.cpp
+++ b/dlls/houndeye.cpp
@@ -1013,7 +1013,7 @@ Task_t	tlHoundWakeUrgent[] =
 {
 	{ TASK_HOUND_OPEN_EYE,		(float)0			},
 	{ TASK_PLAY_SEQUENCE,		(float)ACT_HOP		},
-	{ TASK_FACE_IDEAL,			(float)0			},
+	//{ TASK_FACE_IDEAL,			(float)0			},
 	{ TASK_HOUND_WAKE_UP,		(float)0			},
 };
 


### PR DESCRIPTION
### Fix houndeyes not closing their eyes while sleeping:
This bug is caused by two factors:
- The first one is that the _HOUNDEYE_EYE_FRAMES_ constant defines 4 skins for the eye, while in reality, the model only has 3.

https://github.com/whiteh0le/halflife/blob/ef7c33f8e83673e33cc2a0059b5759d2836bb901/dlls/houndeye.cpp#L38

- The other one is that the _TASK_HOUND_CLOSE_EYE_, loops indefinitely because it doesn't call the _TaskComplete()_ function, this also makes the houndeyes sleep forever until a sound or the player disturbs them.

https://github.com/whiteh0le/halflife/blob/ef7c33f8e83673e33cc2a0059b5759d2836bb901/dlls/houndeye.cpp#L791-L802

The fix is simple, just write an _else_ block and call _TaskComplete()_, unfortunately this makes the houndeyes wake up immediately as the schedule completes, That's why I added the _TASK_WAIT_INDEFINITE_ to the schedule to maintain the old behavior.

https://github.com/whiteh0le/halflife/blob/ef7c33f8e83673e33cc2a0059b5759d2836bb901/dlls/houndeye.cpp#L957-L971

### Fix Houndeyes freezing after waking up:
I think this bug needs an explanation, sometimes when the player makes a loud sound near an asleep houndeye it will wake up abruptly and freeze in place, the houndeye will ignore the player completely for the rest of the game.
This is caused by the _TASK_FACE_IDEAL_. In this task, the monster will try to face the player using the _yaw_speed_ variable, unfortunately this variable is set to zero so the monster can never complete the task.

I decided to disable this task as is not really needed because the houndeye will call _TASK_FACE_IDEAL_ on other schedules.

https://github.com/whiteh0le/halflife/blob/ef7c33f8e83673e33cc2a0059b5759d2836bb901/dlls/houndeye.cpp#L1011-L1018

![Houndeyes sleeping](https://user-images.githubusercontent.com/5395186/79629134-f0733f80-8146-11ea-9a1c-6eb05f8e40f2.jpg)
