### PR TITLE
Add viewroll and viewmodel bob tilt | Returns old bobbing from the WON/retail version | Addresses issue #1544

### DIFF
--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -83,6 +83,9 @@ extern client_sprite_t *GetSpriteList(client_sprite_t *pList, const char *psz, i
 
 extern cvar_t *sensitivity;
 cvar_t *cl_lw = NULL;
+cvar_t *cl_rollangle;
+cvar_t *cl_rollspeed;
+cvar_t *cl_viewroll;
 
 void ShutdownInput (void);
 
@@ -321,6 +324,9 @@ void CHud :: Init( void )
 
 	CVAR_CREATE( "hud_classautokill", "1", FCVAR_ARCHIVE | FCVAR_USERINFO );		// controls whether or not to suicide immediately on TF class switch
 	CVAR_CREATE( "hud_takesshots", "0", FCVAR_ARCHIVE );		// controls whether or not to automatically take screenshots at the end of a round
+	cl_rollangle = CVAR_CREATE( "cl_rollangle", "0.65", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
+	cl_rollspeed = CVAR_CREATE( "cl_rollspeed", "300", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
+	cl_viewroll = CVAR_CREATE( "cl_viewroll", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
 
 
 	m_iLogo = 0;

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -325,8 +325,8 @@ void CHud :: Init( void )
 
 	CVAR_CREATE( "hud_classautokill", "1", FCVAR_ARCHIVE | FCVAR_USERINFO );		// controls whether or not to suicide immediately on TF class switch
 	CVAR_CREATE( "hud_takesshots", "0", FCVAR_ARCHIVE );		// controls whether or not to automatically take screenshots at the end of a round
-	cl_rollangle = CVAR_CREATE( "cl_rollangle", "0.65", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
-	cl_rollspeed = CVAR_CREATE( "cl_rollspeed", "300", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
+	cl_rollangle = CVAR_CREATE( "cl_viewrollangle", "0.65", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
+	cl_rollspeed = CVAR_CREATE( "cl_viewrollspeed", "300", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
 	cl_viewroll = CVAR_CREATE( "cl_viewroll", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
 	cl_bobtilt = CVAR_CREATE( "cl_bobtilt", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
 

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -86,6 +86,7 @@ cvar_t *cl_lw = NULL;
 cvar_t *cl_rollangle;
 cvar_t *cl_rollspeed;
 cvar_t *cl_viewroll;
+cvar_t *cl_bobtilt;
 
 void ShutdownInput (void);
 
@@ -327,6 +328,7 @@ void CHud :: Init( void )
 	cl_rollangle = CVAR_CREATE( "cl_rollangle", "0.65", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
 	cl_rollspeed = CVAR_CREATE( "cl_rollspeed", "300", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
 	cl_viewroll = CVAR_CREATE( "cl_viewroll", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
+	cl_bobtilt = CVAR_CREATE( "cl_bobtilt", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
 
 
 	m_iLogo = 0;

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -662,10 +662,11 @@ void V_CalcNormalRefdef ( struct ref_params_s *pparams )
 	view->origin[2] += bob;
 
 	// throw in a little tilt.
+	extern cvar_t *cl_bobtilt;
 	view->angles[YAW]   -= bob * 0.5;
 	view->angles[ROLL]  -= bob * 1;
 	view->angles[PITCH] -= bob * 0.3;
-
+	if (cl_bobtilt->value == 1) VectorCopy(view->angles, view->curstate.angles);
 	// pushing the view origin down off of the same X/Z plane as the ent's origin will give the
 	// gun a very nice 'shifting' effect when the player looks up/down. If there is a problem
 	// with view model distortion, this may be a cause. (SJB). 

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -401,6 +401,9 @@ V_CalcViewRoll
 Roll is induced by movement and damage
 ==============
 */
+extern cvar_t *cl_rollangle;
+extern cvar_t *cl_rollspeed;
+extern cvar_t *cl_viewroll;
 void V_CalcViewRoll ( struct ref_params_s *pparams )
 {
 	float		side;
@@ -409,7 +412,8 @@ void V_CalcViewRoll ( struct ref_params_s *pparams )
 	viewentity = gEngfuncs.GetEntityByIndex( pparams->viewentity );
 	if ( !viewentity )
 		return;
-
+	if (cl_viewroll->value==1) pparams->viewangles[ROLL] = V_CalcRoll(pparams->viewangles, pparams->simvel, cl_rollangle->value, cl_rollspeed->value) * 4;
+	
 	side = V_CalcRoll ( viewentity->angles, pparams->simvel, pparams->movevars->rollangle, pparams->movevars->rollspeed );
 
 	pparams->viewangles[ROLL] += side;


### PR DESCRIPTION
# About
Since it was removed, many players have requested the return of the old bobbing that the retail version of *Half-Life* and its expansions and mods had. This PR returns that. The reason I have made this PR is because of issue #1544 which has been up for many years.

# Features
- Returns viewmodel bob tilt
- Returns viewroll
- Adds `cl_bobtilt` command to enable or disable bobtilt (disabled by default)
- Adds `cl_viewroll` command to turn viewroll on and off easily (off by default)
## Usage
- `cl_bobtilt` - change its value to `1` to enable bobtilt, so the viewmodel bobs diagonally.
- `cl_viewroll` - change its value to `1` to enable viewroll, so the FOV tilts when strafing and going diagonal. Additionally, you can still use the `cl_viewrollangle` and `cl_viewrollspeed` CVars.

Resolves #1544