### PR TITLE
Add primary shotgun player attack animation

### DIFF
--- a/dlls/shotgun.cpp
+++ b/dlls/shotgun.cpp
@@ -149,6 +149,9 @@ void CShotgun::PrimaryAttack()
 
 	m_pPlayer->pev->effects = (int)(m_pPlayer->pev->effects) | EF_MUZZLEFLASH;
 
+	// player "shoot" animation
+	m_pPlayer->SetAnimation( PLAYER_ATTACK1 );
+
 	Vector vecSrc	 = m_pPlayer->GetGunPosition( );
 	Vector vecAiming = m_pPlayer->GetAutoaimVector( AUTOAIM_5DEGREES );
 


### PR DESCRIPTION
This PR adds the missing primary player shotgun animation.

# Before

![before](https://user-images.githubusercontent.com/729372/104814927-73f9b400-57df-11eb-99dd-4590d5b16d4c.gif)

# After

![after](https://user-images.githubusercontent.com/729372/104814928-79ef9500-57df-11eb-994c-3f283dbb0169.gif)