### PR TITLE
Force player to firstperson if maxplayers > 1 and player is already in thirdperson

### DIFF
--- a/cl_dll/in_camera.cpp
+++ b/cl_dll/in_camera.cpp
@@ -153,6 +153,8 @@ extern trace_t SV_ClipMoveToEntity (edict_t *ent, vec3_t start, vec3_t mins, vec
 void CL_DLLEXPORT CAM_Think( void )
 {
 //	RecClCamThink();
+	if ( gEngfuncs.GetMaxClients() > 1 && CL_IsThirdPerson() )
+		CAM_ToFirstPerson();
 
 	vec3_t origin;
 	vec3_t ext, pnt, camForward, camRight, camUp;


### PR DESCRIPTION
Hello. This fixes #2622 on the client side.

**Reason for this change/Motivation:**
Thirdperson can at the current state be potentially used to cheat in HLDM/AG without any modifications of the client DLL.
If you are on a maxplayers = 1 & deathmatch 0 server OR you are not connected at all and use these commands in the console:
```
sv_cheats 1
thirdperson // or cam_command 1
```
And then join a multiplayer server you will be in thirdperson mode, even though that normally isn't allowed, but the code in HLDM only checks if you can be in thirdperson after you type "thirdperson" **WHILE on a multiplayer server.** 

The game breaking part is pretty obvious, any players/entities that are in the player's PVS (from the origin they are standing at, not the camera's origin) are visible through walls like mentioned in the #2622 issue.

This snippet from cl_dll/in_camera.cpp shows why you cannot switch to thirdperson once you are on a multiplayer server:
```
   368	void CAM_ToThirdPerson(void)
   369	{ 
   370		vec3_t viewangles;
       
   371	#if !defined( _DEBUG )
   372		if ( gEngfuncs.GetMaxClients() > 1 )
   373		{
   374			// no thirdperson in multiplayer.
   375			return;
   376		}
   377	#endif
```
But nothing in in_camera.cpp or anywhere else resets it or checks if you had it set up before you joined the server.

This fix disables thirdperson by checking on every CAM_Think if the player is on a **maxplayers > 1 server** and if **he's in thirdperson** and forces him to **firstperson** if so (and therefore resetting `cam_command` to 0 as well, if he used that instead of the "thirdperson" command):
```
if ( gEngfuncs.GetMaxClients() > 1 && CL_IsThirdPerson() )
		CAM_ToFirstPerson();
```

**Ricochet** does this as part of its game in on every view.cpp - when you die in Ricochet it switches to thirdperson and vice versa, the side-effect is that this bug is fixed and you cannot switch to thirdperson:
https://github.com/ValveSoftware/halflife/blob/c7240b965743a53a29491dd49320c88eecf6257b/ricochet/cl_dll/view.cpp#L526-L551

**DMC** outright disables the `thirdperson` command and `cam_command 1` cvar as there it doesn't matter as the game is multiplayer-only.
https://github.com/ValveSoftware/halflife/blob/c7240b965743a53a29491dd49320c88eecf6257b/dmc/cl_dll/in_camera.cpp#L436-L443
