### PR TITLE
Add support for Github action workload for halflife

### DIFF
--- a/.github/workflows/build-halflife.yml
+++ b/.github/workflows/build-halflife.yml
@@ -1,0 +1,224 @@
+name: build-halflife
+
+on: [push]
+
+env:
+  DEBUG_CONFIGURATION: Debug
+  RELEASE_CONFIGURATION: Release
+  PROJECT_FILE_PATH: projects/vs2019/projects.sln
+  UTIL_FILE_PATH: projects/vs2019/utils.sln
+
+jobs:
+  game-dlls:
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Build debug game dlls
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /m ${{env.PROJECT_FILE_PATH}} /p:Configuration=${{env.DEBUG_CONFIGURATION}}
+
+    - name: Package debug game dlls
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        New-Item -Force -ItemType Directory @("$env:TEMP\debug","$env:TEMP\debug\valve","$env:TEMP\debug\dmc","$env:TEMP\debug\ricochet")
+        Copy-Item -Force projects/vs2019/${{env.DEBUG_CONFIGURATION}}/hldll/hl.dll $env:TEMP/debug/valve
+        Copy-Item -Force projects/vs2019/${{env.DEBUG_CONFIGURATION}}/hl_cdll/client.dll $env:TEMP/debug/valve
+        Copy-Item -Force projects/vs2019/${{env.DEBUG_CONFIGURATION}}/dmcdll/dmc.dll $env:TEMP/debug/dmc
+        Copy-Item -Force projects/vs2019/${{env.DEBUG_CONFIGURATION}}/dmc_cdll/client.dll $env:TEMP/debug/dmc
+        Copy-Item -Force projects/vs2019/${{env.DEBUG_CONFIGURATION}}/ricochetdll/mp.dll $env:TEMP/debug/ricochet
+        Copy-Item -Force projects/vs2019/${{env.DEBUG_CONFIGURATION}}/ricochet_cdll/client.dll $env:TEMP/debug/ricochet
+        Compress-Archive -LiteralPath $env:TEMP\debug -DestinationPath .\debug-game-dlls.zip -Force
+
+    - name: Upload debug game dlls
+      uses: actions/upload-artifact@v2
+      with:
+        name: debug-game-libs
+        path: ./debug-game-dlls.zip
+
+    - name: Build release game dlls
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /m ${{env.PROJECT_FILE_PATH}} /p:Configuration=${{env.RELEASE_CONFIGURATION}}
+
+    - name: Package release game dlls
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        New-Item -Force -ItemType Directory @("$env:TEMP\release","$env:TEMP\release\valve","$env:TEMP\release\dmc","$env:TEMP\release\ricochet")
+        Copy-Item -Force projects/vs2019/${{env.RELEASE_CONFIGURATION}}/hldll/hl.dll $env:TEMP/release/valve
+        Copy-Item -Force projects/vs2019/${{env.RELEASE_CONFIGURATION}}/hl_cdll/client.dll $env:TEMP/release/valve
+        Copy-Item -Force projects/vs2019/${{env.RELEASE_CONFIGURATION}}/dmcdll/dmc.dll $env:TEMP/release/dmc
+        Copy-Item -Force projects/vs2019/${{env.RELEASE_CONFIGURATION}}/dmc_cdll/client.dll $env:TEMP/release/dmc
+        Copy-Item -Force projects/vs2019/${{env.RELEASE_CONFIGURATION}}/ricochetdll/mp.dll $env:TEMP/release/ricochet
+        Copy-Item -Force projects/vs2019/${{env.RELEASE_CONFIGURATION}}/ricochet_cdll/client.dll $env:TEMP/release/ricochet
+        Compress-Archive -LiteralPath $env:TEMP\release -DestinationPath .\release-game-dlls.zip -Force
+
+    - name: Upload release game libs
+      uses: actions/upload-artifact@v2
+      with:
+        name: release-game-libs
+        path: ./release-game-dlls.zip
+
+  game-so-libs:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Update sources to include xenial main
+      run: sudo su -c "echo 'deb http://dk.archive.ubuntu.com/ubuntu/ xenial main' >> /etc/apt/sources.list"
+
+    - name: Update sources to include xenial universe
+      run: sudo su -c "echo 'deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe' >> /etc/apt/sources.list"
+
+    - name: Update packages
+      run: sudo apt update -y
+
+    - name: Install make
+      run: sudo apt-get install make
+
+    - name: Install g++-4.8
+      run: sudo apt install g++-4.8 gcc-4.8 -y
+
+    - name: Install headers
+      run: sudo apt-get install gcc-4.8-multilib g++-4.8-multilib -y
+
+    - name: Build debug Linux so libs
+      run: cd linux && make all CFG=${{env.DEBUG_CONFIGURATION}}
+
+    - name: Package debug Linux so libs
+      run: |
+        cd linux
+        mkdir ${{env.DEBUG_CONFIGURATION}}/hl && mv ${{env.DEBUG_CONFIGURATION}}/hl.so ${{env.DEBUG_CONFIGURATION}}/hl && mv ${{env.DEBUG_CONFIGURATION}}/client.so ${{env.DEBUG_CONFIGURATION}}/hl
+        mkdir ${{env.DEBUG_CONFIGURATION}}/dmc && mv ${{env.DEBUG_CONFIGURATION}}/dmc.so ${{env.DEBUG_CONFIGURATION}}/dmc && mv ${{env.DEBUG_CONFIGURATION}}/client_dmc.so ${{env.DEBUG_CONFIGURATION}}/dmc
+        mkdir ${{env.DEBUG_CONFIGURATION}}/ricochet && mv ${{env.DEBUG_CONFIGURATION}}/ricochet.so ${{env.DEBUG_CONFIGURATION}}/ricochet && mv ${{env.DEBUG_CONFIGURATION}}/client_ricochet.so ${{env.DEBUG_CONFIGURATION}}/ricochet
+        zip -r debug-game-linux-libs.zip ${{env.DEBUG_CONFIGURATION}}/hl ${{env.DEBUG_CONFIGURATION}}/dmc ${{env.DEBUG_CONFIGURATION}}/ricochet
+
+    - name: Upload debug Linux game libs
+      uses: actions/upload-artifact@v2
+      with:
+        name: debug-game-linux-libs
+        path: ./linux/debug-game-linux-libs.zip
+
+    - name: Build release Linux so libs
+      run: cd linux && make all CFG=${{env.RELEASE_CONFIGURATION}}
+
+    - name: Package release Linux so libs
+      run: |
+        cd linux
+        mkdir ${{env.RELEASE_CONFIGURATION}}/hl && mv ${{env.RELEASE_CONFIGURATION}}/hl.so ${{env.RELEASE_CONFIGURATION}}/hl && mv ${{env.RELEASE_CONFIGURATION}}/client.so ${{env.RELEASE_CONFIGURATION}}/hl
+        mkdir ${{env.RELEASE_CONFIGURATION}}/dmc && mv ${{env.RELEASE_CONFIGURATION}}/dmc.so ${{env.RELEASE_CONFIGURATION}}/dmc && mv ${{env.RELEASE_CONFIGURATION}}/client_dmc.so ${{env.RELEASE_CONFIGURATION}}/dmc
+        mkdir ${{env.RELEASE_CONFIGURATION}}/ricochet && mv ${{env.RELEASE_CONFIGURATION}}/ricochet.so ${{env.RELEASE_CONFIGURATION}}/ricochet && mv ${{env.RELEASE_CONFIGURATION}}/client_ricochet.so ${{env.RELEASE_CONFIGURATION}}/ricochet
+        zip -r release-game-linux-libs.zip ${{env.RELEASE_CONFIGURATION}}/hl ${{env.RELEASE_CONFIGURATION}}/dmc ${{env.RELEASE_CONFIGURATION}}/ricochet
+
+    - name: Upload release Linux game libs
+      uses: actions/upload-artifact@v2
+      with:
+        name: release-game-linux-libs
+        path: ./linux/release-game-linux-libs.zip
+
+  game-dylibs:
+    runs-on: macOS-10.15
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install MacOSX10.8.sdk
+      run: |
+        mkdir /tmp/sdk && cd /tmp/sdk
+        curl -sSL https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.8.sdk.tar.xz > sdk.tar
+        tar -xvf sdk.tar
+        sudo ln -s /tmp/sdk/MacOSX10.8.sdk $(/usr/bin/xcode-select -print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk
+        rm sdk.tar
+
+    - name: Build debug macOS dylibs
+      run: cd linux && make all CFG=${{env.DEBUG_CONFIGURATION}}
+
+    - name: Package debug macOS dylibs
+      run: |
+        cd linux
+        mkdir ${{env.DEBUG_CONFIGURATION}}/hl && mv ${{env.DEBUG_CONFIGURATION}}/hl.dylib ${{env.DEBUG_CONFIGURATION}}/hl && mv ${{env.DEBUG_CONFIGURATION}}/client.dylib ${{env.DEBUG_CONFIGURATION}}/hl
+        mkdir ${{env.DEBUG_CONFIGURATION}}/dmc && mv ${{env.DEBUG_CONFIGURATION}}/dmc.dylib ${{env.DEBUG_CONFIGURATION}}/dmc && mv ${{env.DEBUG_CONFIGURATION}}/client_dmc.dylib ${{env.DEBUG_CONFIGURATION}}/dmc
+        mkdir ${{env.DEBUG_CONFIGURATION}}/ricochet && mv ${{env.DEBUG_CONFIGURATION}}/ricochet.dylib ${{env.DEBUG_CONFIGURATION}}/ricochet && mv ${{env.DEBUG_CONFIGURATION}}/client_ricochet.dylib ${{env.DEBUG_CONFIGURATION}}/ricochet
+        zip -r debug-game-macos-dylibs.zip ${{env.DEBUG_CONFIGURATION}}/hl ${{env.DEBUG_CONFIGURATION}}/dmc ${{env.DEBUG_CONFIGURATION}}/ricochet
+
+    - name: Upload debug macOS game dylibs
+      uses: actions/upload-artifact@v2
+      with:
+        name: debug-game-macos-dylibs
+        path: ./linux/debug-game-macos-dylibs.zip
+
+    - name: Build release macOS dylibs
+      run: cd linux && make all CFG=${{env.RELEASE_CONFIGURATION}}
+
+    - name: Package release macOS dylibs
+      run: |
+        cd linux
+        mkdir ${{env.RELEASE_CONFIGURATION}}/hl && mv ${{env.RELEASE_CONFIGURATION}}/hl.dylib ${{env.RELEASE_CONFIGURATION}}/hl && mv ${{env.RELEASE_CONFIGURATION}}/client.dylib ${{env.RELEASE_CONFIGURATION}}/hl
+        mkdir ${{env.RELEASE_CONFIGURATION}}/dmc && mv ${{env.RELEASE_CONFIGURATION}}/dmc.dylib ${{env.RELEASE_CONFIGURATION}}/dmc && mv ${{env.RELEASE_CONFIGURATION}}/client_dmc.dylib ${{env.RELEASE_CONFIGURATION}}/dmc
+        mkdir ${{env.RELEASE_CONFIGURATION}}/ricochet && mv ${{env.RELEASE_CONFIGURATION}}/ricochet.dylib ${{env.RELEASE_CONFIGURATION}}/ricochet && mv ${{env.RELEASE_CONFIGURATION}}/client_ricochet.dylib ${{env.RELEASE_CONFIGURATION}}/ricochet
+        zip -r release-game-macos-dylibs.zip ${{env.RELEASE_CONFIGURATION}}/hl ${{env.RELEASE_CONFIGURATION}}/dmc ${{env.RELEASE_CONFIGURATION}}/ricochet
+
+    - name: Upload release macOS game dylibs
+      uses: actions/upload-artifact@v2
+      with:
+        name: release-game-macos-dylibs
+        path: ./linux/release-game-macos-dylibs.zip
+
+  windows-util-tools:
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Download openGL libraries
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        New-Item -ItemType directory -Path @('ext','ext/GL')
+        Invoke-WebRequest -Uri "http://www.songho.ca/opengl/files/glaux.h" | select -ExpandProperty Content | Out-File ext/GL/glaux.h
+        Invoke-WebRequest -Uri "http://www.songho.ca/opengl/files/glaux.lib" -OutFile ext/glaux.lib
+        Invoke-WebRequest -Uri "http://www.opengl.org/resources/libraries/glut/glutdlls37beta.zip" -OutFile $env:TEMP/glut.zip
+        Expand-Archive -Path $env:TEMP/glut.zip -DestinationPath ext
+        Move-Item ext/glut.h ext/GL
+
+    - name: Build debug Windows tools
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /m ${{env.UTIL_FILE_PATH}} /p:Configuration=${{env.DEBUG_CONFIGURATION}} /p:IncludePath=../../ext
+
+    - name: Package debug Windows tools
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        New-Item -Force -ItemType Directory $env:TEMP\${{env.DEBUG_CONFIGURATION}}
+        Copy-Item -Force -Recurse -Filter *.exe -Path projects/vs2019/${{env.DEBUG_CONFIGURATION}} -Destination $env:TEMP/${{env.DEBUG_CONFIGURATION}}
+        Copy-Item -Force projects/vs2019/${{env.DEBUG_CONFIGURATION}}/procinfo/procinfo.lib $env:TEMP/${{env.DEBUG_CONFIGURATION}}/Debug/procinfo
+        Compress-Archive -LiteralPath $env:TEMP\${{env.DEBUG_CONFIGURATION}} -DestinationPath .\windows-debug-tools.zip -Force
+
+    - name: Upload debug Windows tools
+      uses: actions/upload-artifact@v2
+      with:
+        name: windows-debug-tools
+        path: ./windows-debug-tools.zip
+
+    - name: Build release Windows tools
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /m ${{env.UTIL_FILE_PATH}} /p:Configuration=${{env.RELEASE_CONFIGURATION}} /p:IncludePath=../../ext
+
+    - name: Package release Windows tools
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        New-Item -Force -ItemType Directory $env:TEMP\${{env.RELEASE_CONFIGURATION}}
+        Copy-Item -Force -Recurse -Filter *.exe -Path projects/vs2019/${{env.RELEASE_CONFIGURATION}} -Destination $env:TEMP/${{env.RELEASE_CONFIGURATION}}
+        Copy-Item -Force projects/vs2019/${{env.RELEASE_CONFIGURATION}}/procinfo/procinfo.lib $env:TEMP/${{env.RELEASE_CONFIGURATION}}/Release/procinfo
+        Compress-Archive -LiteralPath $env:TEMP\${{env.RELEASE_CONFIGURATION}} -DestinationPath .\windows-release-tools.zip -Force
+
+    - name: Upload release tools
+      uses: actions/upload-artifact@v2
+      with:
+        name: windows-release-tools
+        path: ./windows-release-tools.zip

--- a/cl_dll/cl_util.h
+++ b/cl_dll/cl_util.h
@@ -164,7 +164,6 @@ inline void PlaySound( int iSound, float vol ) { gEngfuncs.pfnPlaySoundByIndex( 
 
 #define max(a, b)  (((a) > (b)) ? (a) : (b))
 #define min(a, b)  (((a) < (b)) ? (a) : (b))
-#define fabs(x)	   ((x) > 0 ? (x) : 0 - (x))
 
 void ScaleColors( int &r, int &g, int &b, int a );
 

--- a/cl_dll/in_camera.cpp
+++ b/cl_dll/in_camera.cpp
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright ï¿½ 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //
@@ -99,7 +99,7 @@ float MoveToward( float cur, float goal, float maxspeed )
 {
 	if( cur != goal )
 	{
-		if( abs( cur - goal ) > 180.0 )
+		if( fabs( cur - goal ) > 180.0 )
 		{
 			if( cur < goal )
 				cur += 360.0;
@@ -383,7 +383,7 @@ void CL_DLLEXPORT CAM_Think( void )
 		if( camAngles[ PITCH ] - viewangles[ PITCH ] != cam_idealpitch->value )
 			camAngles[ PITCH ] = MoveToward( camAngles[ PITCH ], cam_idealpitch->value + viewangles[ PITCH ], CAM_ANGLE_SPEED );
 
-		if( abs( camAngles[ 2 ] - cam_idealdist->value ) < 2.0 )
+		if( fabs( camAngles[ 2 ] - cam_idealdist->value ) < 2.0 )
 			camAngles[ 2 ] = cam_idealdist->value;
 		else
 			camAngles[ 2 ] += ( cam_idealdist->value - camAngles[ 2 ] ) / 4.0;

--- a/cl_dll/inputw32.cpp
+++ b/cl_dll/inputw32.cpp
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright ï¿½ 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //
@@ -908,7 +908,7 @@ void IN_JoyMove ( float frametime, usercmd_t *cmd )
 				// y=ax^b; where a = 300 and b = 1.3
 				// also x values are in increments of 800 (so this is factored out)
 				// then bounds check result to level out excessively high spin rates
-				fTemp = 300.0 * pow(abs(fAxisValue) / 800.0, 1.3);
+				fTemp = 300.0 * pow(fabs(fAxisValue) / 800.0, 1.3);
 				if (fTemp > 14000.0)
 					fTemp = 14000.0;
 				// restore direction information

--- a/dlls/bmodels.cpp
+++ b/dlls/bmodels.cpp
@@ -550,13 +550,13 @@ void CFuncRotating :: RampPitchVol (int fUp)
 	
 	// get current angular velocity
 
-	vecCur = abs(vecAVel.x != 0 ? vecAVel.x : (vecAVel.y != 0 ? vecAVel.y : vecAVel.z));
+	vecCur = fabs(vecAVel.x != 0 ? vecAVel.x : (vecAVel.y != 0 ? vecAVel.y : vecAVel.z));
 	
 	// get target angular velocity
 
 	vecFinal = (pev->movedir.x != 0 ? pev->movedir.x : (pev->movedir.y != 0 ? pev->movedir.y : pev->movedir.z));
 	vecFinal *= pev->speed;
-	vecFinal = abs(vecFinal);
+	vecFinal = fabs(vecFinal);
 
 	// calc volume and pitch as % of final vol and pitch
 
@@ -592,9 +592,9 @@ void CFuncRotating :: SpinUp( void )
 	vecAVel = pev->avelocity;// cache entity's rotational velocity
 
 	// if we've met or exceeded target speed, set target speed and stop thinking
-	if (	abs(vecAVel.x) >= abs(pev->movedir.x * pev->speed)	&&
-			abs(vecAVel.y) >= abs(pev->movedir.y * pev->speed)	&&
-			abs(vecAVel.z) >= abs(pev->movedir.z * pev->speed) )
+	if (	fabs(vecAVel.x) >= fabs(pev->movedir.x * pev->speed)	&&
+			fabs(vecAVel.y) >= fabs(pev->movedir.y * pev->speed)	&&
+			fabs(vecAVel.z) >= fabs(pev->movedir.z * pev->speed) )
 	{
 		pev->avelocity = pev->movedir * pev->speed;// set speed in case we overshot
 		EMIT_SOUND_DYN(ENT(pev), CHAN_STATIC, (char *)STRING(pev->noiseRunning), 

--- a/dlls/func_break.cpp
+++ b/dlls/func_break.cpp
@@ -596,7 +596,7 @@ void CBreakable::Die( void )
 	// The more negative pev->health, the louder
 	// the sound should be.
 
-	fvol = RANDOM_FLOAT(0.85, 1.0) + (abs(pev->health) / 100.0);
+	fvol = RANDOM_FLOAT(0.85, 1.0) + (fabs(pev->health) / 100.0);
 
 	if (fvol > 1.0)
 		fvol = 1.0;

--- a/dlls/plats.cpp
+++ b/dlls/plats.cpp
@@ -1126,7 +1126,7 @@ void CFuncTrackTrain :: UpdateSound( void )
 	if (!pev->noise)
 		return;
 
-	flpitch = TRAIN_STARTPITCH + (abs(pev->speed) * (TRAIN_MAXPITCH - TRAIN_STARTPITCH) / TRAIN_MAXSPEED);
+	flpitch = TRAIN_STARTPITCH + (fabs(pev->speed) * (TRAIN_MAXPITCH - TRAIN_STARTPITCH) / TRAIN_MAXSPEED);
 
 	if (!m_soundPlaying)
 	{

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -2072,7 +2072,7 @@ void CBasePlayer::CheckTimeBasedDamage()
 		return;
 
 	// only check for time based damage approx. every 2 seconds
-	if (abs(gpGlobals->time - m_tbdPrev) < 2.0)
+	if (fabs(gpGlobals->time - m_tbdPrev) < 2.0)
 		return;
 	
 	m_tbdPrev = gpGlobals->time;

--- a/dlls/roach.cpp
+++ b/dlls/roach.cpp
@@ -262,7 +262,7 @@ void CRoach :: MonsterThink( void  )
 					pSound = CSoundEnt::SoundPointerForIndex( m_iAudibleList );
 
 					// roach smells food and is just standing around. Go to food unless food isn't on same z-plane.
-					if ( pSound && abs( pSound->m_vecOrigin.z - pev->origin.z ) <= 3 )
+					if ( pSound && fabs( pSound->m_vecOrigin.z - pev->origin.z ) <= 3 )
 					{
 						PickNewDest( ROACH_SMELL_FOOD );
 						SetActivity ( ACT_WALK );

--- a/dmc/cl_dll/cl_util.h
+++ b/dmc/cl_dll/cl_util.h
@@ -167,7 +167,6 @@ inline void PlaySound( int iSound, float vol ) { gEngfuncs.pfnPlaySoundByIndex( 
 
 #define max(a, b)  (((a) > (b)) ? (a) : (b))
 #define min(a, b)  (((a) < (b)) ? (a) : (b))
-#define fabs(x)	   ((x) > 0 ? (x) : 0 - (x))
 
 void ScaleColors( int &r, int &g, int &b, int a );
 

--- a/dmc/cl_dll/in_camera.cpp
+++ b/dmc/cl_dll/in_camera.cpp
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright ï¿½ 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //
@@ -105,7 +105,7 @@ float MoveToward( float cur, float goal, float maxspeed )
 {
 	if( cur != goal )
 	{
-		if( abs( cur - goal ) > 180.0 )
+		if( fabs( cur - goal ) > 180.0 )
 		{
 			if( cur < goal )
 				cur += 360.0;
@@ -387,7 +387,7 @@ void EXPORT CAM_Think( void )
 		if( camAngles[ PITCH ] - viewangles[ PITCH ] != cam_idealpitch->value )
 			camAngles[ PITCH ] = MoveToward( camAngles[ PITCH ], cam_idealpitch->value + viewangles[ PITCH ], CAM_ANGLE_SPEED );
 
-		if( abs( camAngles[ 2 ] - cam_idealdist->value ) < 2.0 )
+		if( fabs( camAngles[ 2 ] - cam_idealdist->value ) < 2.0 )
 			camAngles[ 2 ] = cam_idealdist->value;
 		else
 			camAngles[ 2 ] += ( cam_idealdist->value - camAngles[ 2 ] ) / 4.0;

--- a/dmc/cl_dll/inputw32.cpp
+++ b/dmc/cl_dll/inputw32.cpp
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright ï¿½ 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //
@@ -753,7 +753,7 @@ void IN_JoyMove ( float frametime, usercmd_t *cmd )
 				// y=ax^b; where a = 300 and b = 1.3
 				// also x values are in increments of 800 (so this is factored out)
 				// then bounds check result to level out excessively high spin rates
-				fTemp = 300.0 * pow(abs(fAxisValue) / 800.0, 1.3);
+				fTemp = 300.0 * pow(fabs(fAxisValue) / 800.0, 1.3);
 				if (fTemp > 14000.0)
 					fTemp = 14000.0;
 				// restore direction information

--- a/dmc/cl_dll/util.h
+++ b/dmc/cl_dll/util.h
@@ -120,7 +120,6 @@ inline void PlaySound( int iSound, float vol ) { gEngfuncs.pfnPlaySoundByIndex( 
 
 #define max(a, b)  (((a) > (b)) ? (a) : (b))
 #define min(a, b)  (((a) < (b)) ? (a) : (b))
-#define fabs(x)	   ((x) > 0 ? (x) : 0 - (x))
 
 void ScaleColors( int &r, int &g, int &b, int a );
 

--- a/dmc/dlls/bmodels.cpp
+++ b/dmc/dlls/bmodels.cpp
@@ -550,13 +550,13 @@ void CFuncRotating :: RampPitchVol (int fUp)
 	
 	// get current angular velocity
 
-	vecCur = abs(vecAVel.x != 0 ? vecAVel.x : (vecAVel.y != 0 ? vecAVel.y : vecAVel.z));
+	vecCur = fabs(vecAVel.x != 0 ? vecAVel.x : (vecAVel.y != 0 ? vecAVel.y : vecAVel.z));
 	
 	// get target angular velocity
 
 	vecFinal = (pev->movedir.x != 0 ? pev->movedir.x : (pev->movedir.y != 0 ? pev->movedir.y : pev->movedir.z));
 	vecFinal *= pev->speed;
-	vecFinal = abs(vecFinal);
+	vecFinal = fabs(vecFinal);
 
 	// calc volume and pitch as % of final vol and pitch
 
@@ -592,9 +592,9 @@ void CFuncRotating :: SpinUp( void )
 	vecAVel = pev->avelocity;// cache entity's rotational velocity
 
 	// if we've met or exceeded target speed, set target speed and stop thinking
-	if (	abs(vecAVel.x) >= abs(pev->movedir.x * pev->speed)	&&
-			abs(vecAVel.y) >= abs(pev->movedir.y * pev->speed)	&&
-			abs(vecAVel.z) >= abs(pev->movedir.z * pev->speed) )
+	if (	fabs(vecAVel.x) >= fabs(pev->movedir.x * pev->speed)	&&
+			fabs(vecAVel.y) >= fabs(pev->movedir.y * pev->speed)	&&
+			fabs(vecAVel.z) >= fabs(pev->movedir.z * pev->speed) )
 	{
 		pev->avelocity = pev->movedir * pev->speed;// set speed in case we overshot
 		EMIT_SOUND_DYN(ENT(pev), CHAN_STATIC, (char *)STRING(pev->noiseRunning), 

--- a/dmc/dlls/func_break.cpp
+++ b/dmc/dlls/func_break.cpp
@@ -590,7 +590,7 @@ void CBreakable::Die( void )
 	// The more negative pev->health, the louder
 	// the sound should be.
 
-	fvol = RANDOM_FLOAT(0.85, 1.0) + (abs(pev->health) / 100.0);
+	fvol = RANDOM_FLOAT(0.85, 1.0) + (fabs(pev->health) / 100.0);
 
 	if (fvol > 1.0)
 		fvol = 1.0;

--- a/dmc/dlls/plats.cpp
+++ b/dmc/dlls/plats.cpp
@@ -1126,7 +1126,7 @@ void CFuncTrackTrain :: UpdateSound( void )
 	if (!pev->noise)
 		return;
 
-	flpitch = TRAIN_STARTPITCH + (abs(pev->speed) * (TRAIN_MAXPITCH - TRAIN_STARTPITCH) / TRAIN_MAXSPEED);
+	flpitch = TRAIN_STARTPITCH + (fabs(pev->speed) * (TRAIN_MAXPITCH - TRAIN_STARTPITCH) / TRAIN_MAXSPEED);
 
 	if (!m_soundPlaying)
 	{

--- a/dmc/dlls/player.cpp
+++ b/dmc/dlls/player.cpp
@@ -2153,7 +2153,7 @@ void CBasePlayer::CheckTimeBasedDamage()
 		return;
 
 	// only check for time based damage approx. every 2 seconds
-	if (abs(gpGlobals->time - m_tbdPrev) < 2.0)
+	if (fabs(gpGlobals->time - m_tbdPrev) < 2.0)
 		return;
 	
 	m_tbdPrev = gpGlobals->time;

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -29,20 +29,18 @@ ARCH=i386
 ELF-GC-DYNSTR=./elf-gc-dynstr
 
 ifeq ($(OS),Linux)
-	CC="/valve/bin/gcc-4.6 -m32"
-	CPLUS="/valve/bin/g++-4.6 -m32"
-	CPP_LIB:=-L$(shell /valve/bin/g++-4.6 -m32 -print-file-name=libstdc++.so | xargs dirname) -lstdc++ -ldl -lpthread
+	CC="gcc-4.8 -m32"
+	CPLUS="g++-4.8 -m32"
+	CPP_LIB:=-L$(shell g++-4.8 -m32 -print-file-name=libstdc++.so | xargs dirname) -lstdc++ -ldl -lpthread
 endif
 
 ifeq ($(OS),Darwin)
     OSXVER := $(shell sw_vers -productVersion)
 	DEVELOPER_DIR := $(shell /usr/bin/xcode-select -print-path)
-	ifeq (,$(findstring 10.7, $(OSXVER))) 
-		BUILDING_ON_LION := 0
+	ifneq (,$(findstring CommandLineTools,$(DEVELOPER_DIR)))
 		COMPILER_BIN_DIR := $(DEVELOPER_DIR)/usr/bin
 		SDK_DIR := $(DEVELOPER_DIR)/SDKs
 	else
-		BUILDING_ON_LION := 1
 		COMPILER_BIN_DIR := $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/bin
 		SDK_DIR := $(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/SDKs
 	endif
@@ -87,9 +85,9 @@ endif
 
 ifeq ($(OS),Darwin)
 # force 387 for FP math so the precision between win32 and linux and osx match
-ARCH_CFLAGS_I486+=-march=pentium-m -mfpmath=387
-ARCH_CFLAGS_I686+=-march=pentium-m -mfpmath=387
-ARCH_CFLAGS_AMD+=-mfpmath=387
+ARCH_CFLAGS_I486+=-march=pentium-m -mfpmath=387 -mno-sse
+ARCH_CFLAGS_I686+=-march=pentium-m -mfpmath=387 -mno-sse
+ARCH_CFLAGS_AMD+=-mfpmath=387 -mno-sse
 endif
 
 

--- a/linux/Makefile.dmc_cdll
+++ b/linux/Makefile.dmc_cdll
@@ -13,14 +13,19 @@ COMMON_OBJ_DIR=$(DMC_OBJ_DIR)/common
 GAME_SHARED_OBJ_DIR=$(DMC_OBJ_DIR)/game_shared
 PM_SHARED_OBJ_DIR=$(DMC_OBJ_DIR)/pm_shared
 
-CFLAGS=$(BASE_CFLAGS) $(ARCH_CFLAGS) -DCLIENT_DLL -DDMC_BUILD -I/usr/include/malloc -D_snwprintf=swprintf \
+DEBUG_CFLAGS=
+ifeq "$(CFG)" "debug"
+	DEBUG_CFLAGS=-D_DEBUG
+endif
+
+CFLAGS=$(BASE_CFLAGS) $(ARCH_CFLAGS) $(DEBUG_CFLAGS) -DCLIENT_DLL -DDMC_BUILD -I/usr/include/malloc -D_snwprintf=swprintf \
 		 -DDISABLE_JUMP_ORIGIN -DDISABLE_VEC_ORIGIN -D_MAX_PATH=PATH_MAX
 		 
 INCLUDEDIRS=-I$(PUBLIC_SRC_DIR) -I../utils/vgui/include -I$(DMC_SRC_DIR)/../dlls \
 	-I../engine -I$(COMMON_SRC_DIR) -I../utils/common -I$(DMC_SRC_DIR)/../pm_shared -I$(DMC_SRC_DIR) -I../game_shared  -I../external
 
 ifeq ($(OS),Darwin)
-LDFLAGS=$(SHLIBLDFLAGS) $(CPP_LIB) -framework Carbon $(CFG)/vgui.dylib -L. -lSDL2-2.0.0
+LDFLAGS=$(SHLIBLDFLAGS) $(CPP_LIB) -framework Carbon release/vgui.dylib -L. -lSDL2-2.0.0
 else
 LDFLAGS=$(SHLIBLDFLAGS) $(CPP_LIB) vgui.so -L. libSDL2-2.0.so.0
 endif
@@ -115,9 +120,9 @@ all: client_dmc.$(SHLIBEXT)
 
 client_dmc.$(SHLIBEXT): $(DMC_OBJS) $(PUBLIC_OBJS) $(COMMON_OBJS) $(GAME_SHARED_OBJS) $(PM_SHARED_OBJS)
 	$(CLINK) -o $(BUILD_DIR)/$@ $(DMC_OBJS) $(PUBLIC_OBJS) $(COMMON_OBJS) $(GAME_SHARED_OBJS) $(PM_SHARED_OBJS) $(LDFLAGS) $(CPP_LIB)
-	p4 edit ../../game/mod/cl_dlls/client.$(SHLIBEXT)
-	cp $(BUILD_DIR)/$@  ../../game/mod/cl_dlls/client.$(SHLIBEXT)
-	./gendbg.sh ../../game/mod/cl_dlls/client.$(SHLIBEXT)
+	#p4 edit ../../game/mod/cl_dlls/client.$(SHLIBEXT)
+	#cp $(BUILD_DIR)/$@  ../../game/mod/cl_dlls/client.$(SHLIBEXT)
+	#./gendbg.sh ../../game/mod/cl_dlls/client.$(SHLIBEXT)
 
 
 $(DMC_OBJ_DIR):

--- a/linux/Makefile.dmcdll
+++ b/linux/Makefile.dmcdll
@@ -12,8 +12,13 @@ DMCDLL_OBJ_DIR=$(BUILD_OBJ_DIR)/dmcdll
 PM_OBJ_DIR=$(DMCDLL_OBJ_DIR)/pm_shared
 GAME_SHARED_OBJ_DIR=$(DMCDLL_OBJ_DIR)/game_shared
 
+DEBUG_CFLAGS=
+ifeq "$(CFG)" "debug"
+	DEBUG_CFLAGS=-D_DEBUG
+endif
+
 #full optimization
-CFLAGS=$(BASE_CFLAGS) $(ARCH_CFLAGS)
+CFLAGS=$(BASE_CFLAGS) $(ARCH_CFLAGS) $(DEBUG_CFLAGS)
 
 DMCDLL_INCLUDEDIRS=-I$(ENGINE_SRC_DIR) -I$(COMMON_SRC_DIR) -I$(PM_SRC_DIR) -I$(GAME_SHARED_SRC_DIR) -I$(PUBLIC_SRC_DIR)
 PM_INCLUDEDIRS=-I$(COMMON_SRC_DIR) -I$(PUBLIC_SRC_DIR)
@@ -93,9 +98,9 @@ dirs:
 
 dmc.$(SHLIBEXT): $(DMCDLL_OBJS) $(PM_OBJS) $(GAME_SHARED_OBJS)
 	$(CLINK) $(SHLIBLDFLAGS) -o $(BUILD_DIR)/$@ $(DMCDLL_OBJS) $(PM_OBJS) $(GAME_SHARED_OBJS) $(LDFLAGS) $(CPP_LIB)
-	p4 edit ../../game/mod/dlls/$@
-	cp $(BUILD_DIR)/$@  ../../game/mod/dlls
-	./gendbg.sh ../../game/mod/dlls/dmc.$(SHLIBEXT)
+	#p4 edit ../../game/mod/dlls/$@
+	#cp $(BUILD_DIR)/$@  ../../game/mod/dlls
+	#./gendbg.sh ../../game/mod/dlls/dmc.$(SHLIBEXT)
 		
 $(DMCDLL_OBJ_DIR)/%.o : $(DMCDLL_SRC_DIR)/%.cpp
 	$(DO_DMCDLL_CC)

--- a/linux/Makefile.hl_cdll
+++ b/linux/Makefile.hl_cdll
@@ -15,13 +15,18 @@ GAME_SHARED_OBJ_DIR=$(HL1_OBJ_DIR)/game_shared
 HL1_SERVER_OBJ_DIR=$(HL1_OBJ_DIR)/server
 PM_SHARED_OBJ_DIR=$(HL1_OBJ_DIR)/pm_shared
 
-CFLAGS=$(BASE_CFLAGS) $(ARCH_CFLAGS) -DCLIENT_DLL -DCLIENT_WEAPONS -DHL_DLL -I/usr/include/malloc -D_snwprintf=swprintf \
+DEBUG_CFLAGS=
+ifeq "$(CFG)" "debug"
+	DEBUG_CFLAGS=-D_DEBUG
+endif
+
+CFLAGS=$(BASE_CFLAGS) $(ARCH_CFLAGS) $(DEBUG_CFLAGS) -DCLIENT_DLL -DCLIENT_WEAPONS -DHL_DLL -I/usr/include/malloc -D_snwprintf=swprintf \
 		 -DDISABLE_JUMP_ORIGIN -DDISABLE_VEC_ORIGIN
 		 
 INCLUDEDIRS=-I$(HL_SRC_DIR) -I../dlls -I../tfc -I$(COMMON_SRC_DIR) -I$(PUBLIC_SRC_DIR) -I../pm_shared -I../engine -I../utils/vgui/include -I ../game_shared -I../external
 
 ifeq ($(OS),Darwin)
-LDFLAGS=$(SHLIBLDFLAGS) $(CPP_LIB) -framework Carbon $(CFG)/vgui.dylib -L. -lSDL2-2.0.0
+LDFLAGS=$(SHLIBLDFLAGS) $(CPP_LIB) -framework Carbon release/vgui.dylib -L. -lSDL2-2.0.0
 else
 LDFLAGS=$(SHLIBLDFLAGS) $(CPP_LIB)  -L$(CFG) vgui.so -L. libSDL2-2.0.so.0
 endif
@@ -137,9 +142,9 @@ all: client.$(SHLIBEXT)
 
 client.$(SHLIBEXT): $(HL1_OBJS) $(PUBLIC_OBJS) $(COMMON_OBJS) $(GAME_SHARED_OBJS) $(DLL_OBJS) $(PM_SHARED_OBJS)
 	$(CLINK) -o $(BUILD_DIR)/$@ $(HL1_OBJS) $(PUBLIC_OBJS) $(COMMON_OBJS) $(GAME_SHARED_OBJS) $(DLL_OBJS) $(PM_SHARED_OBJS) $(LDFLAGS) $(CPP_LIB)
-	p4 edit ../../game/mod/cl_dlls/$@
-	cp $(BUILD_DIR)/$@  ../../game/mod/cl_dlls
-	./gendbg.sh ../../game/mod/cl_dlls/client.$(SHLIBEXT)
+	#p4 edit ../../game/mod/cl_dlls/$@
+	#cp $(BUILD_DIR)/$@  ../../game/mod/cl_dlls
+	#./gendbg.sh ../../game/mod/cl_dlls/client.$(SHLIBEXT)
 
 $(HL1_OBJ_DIR):
 	mkdir -p $(HL1_OBJ_DIR)

--- a/linux/Makefile.hldll
+++ b/linux/Makefile.hldll
@@ -12,8 +12,13 @@ HLWPN_OBJ_DIR=$(HLDLL_OBJ_DIR)/wpn_shared
 PM_OBJ_DIR=$(HLDLL_OBJ_DIR)/pm_shared
 GAME_SHARED_OBJ_DIR=$(HLDLL_OBJ_DIR)/game_shared
 
+DEBUG_CFLAGS=
+ifeq "$(CFG)" "debug"
+	DEBUG_CFLAGS=-D_DEBUG
+endif
+
 #CFLAGS=$(BASE_CFLAGS) $(ARCH_CFLAGS) $(SHLIBCFLAGS) -DCLIENT_WEAPONS
-CFLAGS=$(BASE_CFLAGS)  $(ARCH_CFLAGS)  -DCLIENT_WEAPONS
+CFLAGS=$(BASE_CFLAGS)  $(ARCH_CFLAGS) $(DEBUG_CFLAGS) -DCLIENT_WEAPONS
 #-O3 -ffast-math -fno-strength-reduce
 
 HLDLL_INCLUDEDIRS=-I$(ENGINE_SRC_DIR) -I$(COMMON_SRC_DIR) -I$(PM_SRC_DIR) -I$(GAME_SHARED_SRC_DIR) -I$(PUBLIC_SRC_DIR)
@@ -151,9 +156,9 @@ dirs:
 
 hl.$(SHLIBEXT): $(HLDLL_OBJS) $(HLWPN_OBJS) $(PM_OBJS) $(GAME_SHARED_OBJS)
 	$(CC) $(LDFLAGS) $(SHLIBLDFLAGS) -o $(BUILD_DIR)/$@ $(HLDLL_OBJS) $(HLWPN_OBJS) $(PM_OBJS) $(GAME_SHARED_OBJS)
-	p4 edit ../../game/mod/dlls/hl.$(SHLIBEXT)
-	cp $(BUILD_DIR)/$@  ../../game/mod/dlls/hl.$(SHLIBEXT)
-	./gendbg.sh ../../game/mod/dlls/hl.$(SHLIBEXT)
+	#p4 edit ../../game/mod/dlls/hl.$(SHLIBEXT)
+	#cp $(BUILD_DIR)/$@  ../../game/mod/dlls/hl.$(SHLIBEXT)
+	#./gendbg.sh ../../game/mod/dlls/hl.$(SHLIBEXT)
 	
 $(HLWPN_OBJ_DIR)/%.o : $(HLWPN_SRC_DIR)/%.cpp
 	$(DO_HLWPN_CC)

--- a/linux/Makefile.ricochet_cdll
+++ b/linux/Makefile.ricochet_cdll
@@ -13,14 +13,19 @@ COMMON_OBJ_DIR=$(RICOCHET_OBJ_DIR)/common
 GAME_SHARED_OBJ_DIR=$(RICOCHET_OBJ_DIR)/game_shared
 PM_SHARED_OBJ_DIR=$(RICOCHET_OBJ_DIR)/pm_shared
 
-CFLAGS=$(BASE_CFLAGS) $(ARCH_CFLAGS) -DCLIENT_DLL -I/usr/include/malloc -D_snwprintf=swprintf \
+DEBUG_CFLAGS=
+ifeq "$(CFG)" "debug"
+	DEBUG_CFLAGS=-D_DEBUG
+endif
+
+CFLAGS=$(BASE_CFLAGS) $(ARCH_CFLAGS) $(DEBUG_CFLAGS) -DCLIENT_DLL -I/usr/include/malloc -D_snwprintf=swprintf \
 		 -DDISABLE_JUMP_ORIGIN -DDISABLE_VEC_ORIGIN -D_MAX_PATH=PATH_MAX
 		 
 INCLUDEDIRS=-I$(RICOCHET_SRC_DIR) -I$(RICOCHET_SRC_DIR)/../dlls -I../engine -I$(PUBLIC_SRC_DIR)  -I$(COMMON_SRC_DIR) \
 	 -I../game_shared -I$(RICOCHET_SRC_DIR)/../pm_shared  -I../utils/vgui/include -I../utils/common -I../external
 
 ifeq ($(OS),Darwin)
-LDFLAGS=$(SHLIBLDFLAGS) $(CPP_LIB) -framework Carbon $(CFG)/vgui.dylib -L. -lSDL2-2.0.0
+LDFLAGS=$(SHLIBLDFLAGS) $(CPP_LIB) -framework Carbon release/vgui.dylib -L. -lSDL2-2.0.0
 else
 LDFLAGS=$(SHLIBLDFLAGS) $(CPP_LIB) vgui.so -L. libSDL2-2.0.so.0
 endif
@@ -114,9 +119,9 @@ all: client_ricochet.$(SHLIBEXT)
 
 client_ricochet.$(SHLIBEXT): $(RICOCHET_OBJS) $(PUBLIC_OBJS) $(COMMON_OBJS) $(GAME_SHARED_OBJS) $(PM_SHARED_OBJS)
 	$(CLINK) -o $(BUILD_DIR)/$@ $(RICOCHET_OBJS) $(PUBLIC_OBJS) $(COMMON_OBJS) $(GAME_SHARED_OBJS) $(PM_SHARED_OBJS) $(LDFLAGS)  $(CPP_LIB)
-	p4 edit ../../game/mod/cl_dlls/client.$(SHLIBEXT)
-	cp $(BUILD_DIR)/$@  ../../game/mod/cl_dlls/client.$(SHLIBEXT)
-	./gendbg.sh ../../game/mod/cl_dlls/client.$(SHLIBEXT)		
+	#p4 edit ../../game/mod/cl_dlls/client.$(SHLIBEXT)
+	#cp $(BUILD_DIR)/$@  ../../game/mod/cl_dlls/client.$(SHLIBEXT)
+	#./gendbg.sh ../../game/mod/cl_dlls/client.$(SHLIBEXT)		
 
 $(RICOCHET_OBJ_DIR):
 	mkdir -p $(RICOCHET_OBJ_DIR)

--- a/linux/Makefile.ricochetdll
+++ b/linux/Makefile.ricochetdll
@@ -14,8 +14,13 @@ RICOCHETWPN_OBJ_DIR=$(RICOCHETDLL_OBJ_DIR)/wpn_shared
 PM_OBJ_DIR=$(RICOCHETDLL_OBJ_DIR)/pm_shared
 GAME_SHARED_OBJ_DIR=$(RICOCHETDLL_OBJ_DIR)/game_shared
 
+DEBUG_CFLAGS=
+ifeq "$(CFG)" "debug"
+	DEBUG_CFLAGS=-D_DEBUG
+endif
+
 #CFLAGS=$(BASE_CFLAGS) -g
-CFLAGS=$(BASE_CFLAGS) -O3 -ffast-math -fno-strength-reduce
+CFLAGS=$(BASE_CFLAGS) $(DEBUG_CFLAGS) -O3 -ffast-math -fno-strength-reduce
 
 RICOCHETDLL_INCLUDEDIRS=-I$(ENGINE_SRC_DIR) -I$(COMMON_SRC_DIR) -I$(PM_SRC_DIR) -I$(GAME_SHARED_SRC_DIR) -I$(PUBLIC_SRC_DIR)
 RICOCHETWPN_INCLUDEDIRS=-I$(RICOCHETDLL_SRC_DIR) -I$(ENGINE_SRC_DIR) -I$(COMMON_SRC_DIR) -I$(PM_SRC_DIR) -I$(PUBLIC_SRC_DIR)
@@ -102,9 +107,9 @@ dirs:
 
 ricochet.$(SHLIBEXT): $(RICOCHETDLL_OBJS) $(RICOCHETWPN_OBJS) $(PM_OBJS) $(GAME_SHARED_OBJS)
 	$(CLINK) $(SHLIBLDFLAGS) -o $(BUILD_DIR)/$@ $(RICOCHETDLL_OBJS) $(RICOCHETWPN_OBJS) $(PM_OBJS) $(GAME_SHARED_OBJS) $(LDFLAGS) $(CPP_LIB)
-	p4 edit ../../game/mod/dlls/$@
-	cp $(BUILD_DIR)/$@  ../../game/mod/dlls
-	./gendbg.sh ../../game/mod/dlls/$@
+	#p4 edit ../../game/mod/dlls/$@
+	#cp $(BUILD_DIR)/$@  ../../game/mod/dlls
+	#./gendbg.sh ../../game/mod/dlls/$@
 		
 $(RICOCHETWPN_OBJ_DIR)/%.o : $(RICOCHETWPN_SRC_DIR)/%.cpp
 	$(DO_RICOCHETWPN_CC)

--- a/projects/vs2019/bspinfo.vcxproj
+++ b/projects/vs2019/bspinfo.vcxproj
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{B1227C36-C02C-4914-9675-C6D243D8B36E}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>bspinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\bspinfo\bspinfo.c" />
+    <ClCompile Include="..\..\utils\common\bspfile.c" />
+    <ClCompile Include="..\..\utils\common\cmdlib.c" />
+    <ClCompile Include="..\..\utils\common\scriplib.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\bspfile.h" />
+    <ClInclude Include="..\..\utils\common\cmdlib.h" />
+    <ClInclude Include="..\..\utils\common\scriplib.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/bspinfo.vcxproj.filters
+++ b/projects/vs2019/bspinfo.vcxproj.filters
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{d5586ccb-fc7d-4e19-8bde-8656f3036ed7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\bspinfo">
+      <UniqueIdentifier>{63245e01-3884-4650-b2a4-90c672eb89e9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{23430839-825c-42f8-87f8-5ae8dbcbb612}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\common">
+      <UniqueIdentifier>{b9529791-81ac-4e1b-86b7-e3ae05d40193}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\common">
+      <UniqueIdentifier>{9e2cd4d4-3990-41a2-ae01-1cdcaeb123b2}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\bspinfo\bspinfo.c">
+      <Filter>Source Files\utils\bspinfo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\scriplib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\bspfile.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\cmdlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\bspfile.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\scriplib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\cmdlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/dmc_cdll.vcxproj
+++ b/projects/vs2019/dmc_cdll.vcxproj
@@ -1,0 +1,214 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\common\parsemsg.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\ammo.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\ammohistory.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\ammo_secondary.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\battery.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\cdll_int.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\com_weapons.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\CTF_FlagStatus.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\CTF_HudMessage.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\death.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\demo.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\DMC_Teleporters.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\entity.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\events.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\ev_common.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\ev_hldm.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\GameStudioModelRenderer.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\geiger.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\health.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\hud.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\hud_msg.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\hud_redraw.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\hud_servers.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\hud_spectator.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\hud_update.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\input.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\inputw32.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\in_camera.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\menu.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\message.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\quake\quake_baseentity.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\quake\quake_events.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\quake\quake_objects.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\quake\quake_weapons.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\saytext.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\statusbar.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\status_icons.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\StudioModelRenderer.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\studio_util.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\text_message.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\train.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\tri.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\util.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_CustomObjects.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_int.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_MOTDWindow.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_SchemeManager.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_ScorePanel.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_ServerBrowser.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_SpectatorPanel.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_viewport.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\view.cpp" />
+    <ClCompile Include="..\..\dmc\cl_dll\voice_status.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\quake_gun.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\quake_weapons_all.cpp" />
+    <ClCompile Include="..\..\dmc\pm_shared\pm_debug.c" />
+    <ClCompile Include="..\..\dmc\pm_shared\pm_math.c" />
+    <ClCompile Include="..\..\dmc\pm_shared\pm_shared.c" />
+    <ClCompile Include="..\..\game_shared\vgui_checkbutton2.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_grid.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_helpers.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_listbox.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_loadtga.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_scrollbar2.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_slider2.cpp" />
+    <ClCompile Include="..\..\game_shared\voice_banmgr.cpp" />
+    <ClCompile Include="..\..\public\interface.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\common\parsemsg.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\ammo.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\ammohistory.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\camera.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\cl_dll.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\cl_util.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\com_weapons.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\demo.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\DMC_BSPFile.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\DMC_Teleporters.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\eventscripts.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\ev_hldm.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\GameStudioModelRenderer.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\health.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\hud.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\hud_iface.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\hud_servers.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\hud_servers_priv.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\hud_spectator.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\in_defs.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\kbutton.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\StudioModelRenderer.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\util.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\util_vector.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\vgui_ControlConfigPanel.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\vgui_int.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\vgui_SchemeManager.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\vgui_ScorePanel.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\vgui_ServerBrowser.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\vgui_SpectatorPanel.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\vgui_viewport.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\view.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\voice_status.h" />
+    <ClInclude Include="..\..\dmc\cl_dll\wrect.h" />
+    <ClInclude Include="..\..\dmc\dlls\quake_gun.h" />
+    <ClInclude Include="..\..\dmc\pm_shared\pm_debug.h" />
+    <ClInclude Include="..\..\dmc\pm_shared\pm_defs.h" />
+    <ClInclude Include="..\..\dmc\pm_shared\pm_info.h" />
+    <ClInclude Include="..\..\dmc\pm_shared\pm_materials.h" />
+    <ClInclude Include="..\..\dmc\pm_shared\pm_movevars.h" />
+    <ClInclude Include="..\..\dmc\pm_shared\pm_shared.h" />
+    <ClInclude Include="..\..\game_shared\vgui_checkbutton2.h" />
+    <ClInclude Include="..\..\game_shared\vgui_grid.h" />
+    <ClInclude Include="..\..\game_shared\vgui_helpers.h" />
+    <ClInclude Include="..\..\game_shared\vgui_listbox.h" />
+    <ClInclude Include="..\..\game_shared\vgui_loadtga.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{50BD4CD5-4043-4457-BA51-7CF8FFC43767}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>dmc_cdll</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <TargetName>client</TargetName>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <TargetName>client</TargetName>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;CLIENT_DLL;DMC_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\..\public;..\..\dmc\dlls;..\..\engine;..\..\common;..\..\dmc\pm_shared;..\..\utils\vgui\include;..\..\dmc\cl_dll;..\..\game_shared;..\..\external;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>..\..\utils\vgui\lib\win32_vc6\vgui.lib;wsock32.lib;..\..\lib\public\sdl2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <BaseAddress>
+      </BaseAddress>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;CLIENT_DLL;DMC_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\..\public;..\..\dmc\dlls;..\..\engine;..\..\common;..\..\dmc\pm_shared;..\..\utils\vgui\include;..\..\dmc\cl_dll;..\..\game_shared;..\..\external;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>..\..\utils\vgui\lib\win32_vc6\vgui.lib;wsock32.lib;..\..\lib\public\sdl2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <BaseAddress>
+      </BaseAddress>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/dmc_cdll.vcxproj.filters
+++ b/projects/vs2019/dmc_cdll.vcxproj.filters
@@ -1,0 +1,411 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\_quake">
+      <UniqueIdentifier>{ba2e92e5-2bf1-4a18-bfe8-9bc0a15c543c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_quake\dmc">
+      <UniqueIdentifier>{86d90742-ec24-48ae-b07e-3df59ef6a396}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_quake\dmc\cl_dll">
+      <UniqueIdentifier>{a5a4b4d3-85ff-47c2-bc80-2ff5a63bc0b9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_quake\dmc\cl_dll\quake">
+      <UniqueIdentifier>{4c151355-546d-4443-84c4-1ba971369673}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_quake\dmc\dlls">
+      <UniqueIdentifier>{be83ab2d-f1d8-460a-9305-a04d3d10a47c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\dmc">
+      <UniqueIdentifier>{4bf24b6f-ef41-4f61-b6b0-ce72c3f73024}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\dmc\cl_dll">
+      <UniqueIdentifier>{31fcf31c-1923-42b1-b9fe-01999692a141}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\public">
+      <UniqueIdentifier>{841cb2e7-79c0-401e-902c-1f611e2a9b3b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\common">
+      <UniqueIdentifier>{b9feaf89-58f1-4793-890d-6e83fc5fb5d4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\dmc\pm_shared">
+      <UniqueIdentifier>{d820ee67-598d-43dc-bbde-c2f752cc2042}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\game_shared">
+      <UniqueIdentifier>{edb88f62-96a7-40c3-8359-970e191dc3f6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\dmc">
+      <UniqueIdentifier>{3156f528-cb57-4cd3-b345-721adac4edd3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\dmc\cl_dll">
+      <UniqueIdentifier>{1f8decdb-4fcb-4acc-b89b-eb581ed1ec7d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\dmc\pm_shared">
+      <UniqueIdentifier>{63fd35da-8094-4173-856a-c2f2fedf547d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\common">
+      <UniqueIdentifier>{91fac5dc-7cd5-4d5a-8819-36bdefdb7fd6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\dmc\dlls">
+      <UniqueIdentifier>{32a1be15-b6a8-4181-945a-ef7081d4e4e5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\game_shared">
+      <UniqueIdentifier>{c7b58d57-c9fe-4904-94e4-4c70a89ee725}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\dmc\cl_dll\CTF_FlagStatus.cpp">
+      <Filter>Source Files\_quake\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\CTF_HudMessage.cpp">
+      <Filter>Source Files\_quake\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\DMC_Teleporters.cpp">
+      <Filter>Source Files\_quake\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\ev_hldm.cpp">
+      <Filter>Source Files\_quake\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\quake\quake_weapons.cpp">
+      <Filter>Source Files\_quake\dmc\cl_dll\quake</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\quake\quake_baseentity.cpp">
+      <Filter>Source Files\_quake\dmc\cl_dll\quake</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\quake\quake_events.cpp">
+      <Filter>Source Files\_quake\dmc\cl_dll\quake</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\quake\quake_objects.cpp">
+      <Filter>Source Files\_quake\dmc\cl_dll\quake</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\quake_weapons_all.cpp">
+      <Filter>Source Files\_quake\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\quake_gun.cpp">
+      <Filter>Source Files\_quake\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\studio_util.cpp">
+      <Filter>Source Files\_quake\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_SpectatorPanel.cpp">
+      <Filter>Source Files\_quake\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\input.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\inputw32.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\ammo.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\ammo_secondary.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\ammohistory.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\battery.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\cdll_int.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\com_weapons.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\death.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\demo.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\entity.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\ev_common.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\events.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\GameStudioModelRenderer.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\geiger.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\health.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\hud.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\hud_msg.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\hud_redraw.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\hud_servers.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\hud_spectator.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\hud_update.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\in_camera.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\public\interface.cpp">
+      <Filter>Source Files\public</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\message.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\menu.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\common\parsemsg.cpp">
+      <Filter>Source Files\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\pm_shared\pm_shared.c">
+      <Filter>Source Files\dmc\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\pm_shared\pm_debug.c">
+      <Filter>Source Files\dmc\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\pm_shared\pm_math.c">
+      <Filter>Source Files\dmc\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\util.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\saytext.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\status_icons.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\statusbar.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\StudioModelRenderer.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\text_message.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\train.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\tri.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_int.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_scrollbar2.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_checkbutton2.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_grid.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_helpers.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_listbox.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_loadtga.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\voice_status.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_ScorePanel.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_ServerBrowser.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_viewport.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\view.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\voice_banmgr.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_slider2.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_CustomObjects.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_SchemeManager.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\cl_dll\vgui_MOTDWindow.cpp">
+      <Filter>Source Files\dmc\cl_dll</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\dmc\cl_dll\kbutton.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\ammo.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\ammohistory.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\camera.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\cl_dll.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\cl_util.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\com_weapons.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\demo.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\DMC_BSPFile.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\DMC_Teleporters.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\ev_hldm.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\eventscripts.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\GameStudioModelRenderer.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\health.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\hud.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\hud_iface.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\hud_servers.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\hud_servers_priv.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\hud_spectator.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\in_defs.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\common\parsemsg.h">
+      <Filter>Header Files\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\pm_shared\pm_shared.h">
+      <Filter>Header Files\dmc\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\pm_shared\pm_debug.h">
+      <Filter>Header Files\dmc\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\pm_shared\pm_defs.h">
+      <Filter>Header Files\dmc\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\pm_shared\pm_info.h">
+      <Filter>Header Files\dmc\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\pm_shared\pm_materials.h">
+      <Filter>Header Files\dmc\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\pm_shared\pm_movevars.h">
+      <Filter>Header Files\dmc\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\quake_gun.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\vgui_ControlConfigPanel.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\StudioModelRenderer.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\util.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\util_vector.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\game_shared\vgui_checkbutton2.h">
+      <Filter>Header Files\game_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\game_shared\vgui_grid.h">
+      <Filter>Header Files\game_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\game_shared\vgui_helpers.h">
+      <Filter>Header Files\game_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\game_shared\vgui_listbox.h">
+      <Filter>Header Files\game_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\game_shared\vgui_loadtga.h">
+      <Filter>Header Files\game_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\vgui_SpectatorPanel.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\vgui_int.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\vgui_SchemeManager.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\vgui_ScorePanel.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\vgui_ServerBrowser.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\voice_status.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\wrect.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\vgui_viewport.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\cl_dll\view.h">
+      <Filter>Header Files\dmc\cl_dll</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/dmcdll.vcxproj
+++ b/projects/vs2019/dmcdll.vcxproj
@@ -1,0 +1,190 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\dmc\dlls\animating.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\animation.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\bmodels.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\buttons.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\cbase.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\client.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\combat.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\doors.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\effects.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\explode.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\func_break.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\func_tank.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\game.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\gamerules.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\globals.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\h_ai.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\h_export.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\lights.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\maprules.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\monsters.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\monsterstate.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\multiplay_gamerules.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\nodes.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\observer.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\pathcorner.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\plane.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\plats.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\player.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\quake_gun.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\quake_items.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\quake_nail.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\quake_player.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\quake_rocket.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\quake_weapons_all.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\schedule.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\singleplay_gamerules.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\skill.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\sound.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\spectator.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\subs.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\teamplay_gamerules.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\threewave_gamerules.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\triggers.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\util.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\weapons.cpp" />
+    <ClCompile Include="..\..\dmc\dlls\world.cpp" />
+    <ClCompile Include="..\..\dmc\pm_shared\pm_debug.c" />
+    <ClCompile Include="..\..\dmc\pm_shared\pm_math.c" />
+    <ClCompile Include="..\..\dmc\pm_shared\pm_shared.c" />
+    <ClCompile Include="..\..\game_shared\voice_gamemgr.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\dmc\dlls\activity.h" />
+    <ClInclude Include="..\..\dmc\dlls\activitymap.h" />
+    <ClInclude Include="..\..\dmc\dlls\animation.h" />
+    <ClInclude Include="..\..\dmc\dlls\basemonster.h" />
+    <ClInclude Include="..\..\dmc\dlls\cbase.h" />
+    <ClInclude Include="..\..\dmc\dlls\cdll_dll.h" />
+    <ClInclude Include="..\..\dmc\dlls\client.h" />
+    <ClInclude Include="..\..\dmc\dlls\decals.h" />
+    <ClInclude Include="..\..\dmc\dlls\defaultai.h" />
+    <ClInclude Include="..\..\dmc\dlls\doors.h" />
+    <ClInclude Include="..\..\dmc\dlls\effects.h" />
+    <ClInclude Include="..\..\dmc\dlls\enginecallback.h" />
+    <ClInclude Include="..\..\dmc\dlls\explode.h" />
+    <ClInclude Include="..\..\dmc\dlls\extdll.h" />
+    <ClInclude Include="..\..\dmc\dlls\func_break.h" />
+    <ClInclude Include="..\..\dmc\dlls\gamerules.h" />
+    <ClInclude Include="..\..\dmc\dlls\items.h" />
+    <ClInclude Include="..\..\dmc\dlls\monsterevent.h" />
+    <ClInclude Include="..\..\dmc\dlls\monsters.h" />
+    <ClInclude Include="..\..\dmc\dlls\nodes.h" />
+    <ClInclude Include="..\..\dmc\dlls\plane.h" />
+    <ClInclude Include="..\..\dmc\dlls\player.h" />
+    <ClInclude Include="..\..\dmc\dlls\quake_gun.h" />
+    <ClInclude Include="..\..\dmc\dlls\saverestore.h" />
+    <ClInclude Include="..\..\dmc\dlls\schedule.h" />
+    <ClInclude Include="..\..\dmc\dlls\scripted.h" />
+    <ClInclude Include="..\..\dmc\dlls\scriptevent.h" />
+    <ClInclude Include="..\..\dmc\dlls\skill.h" />
+    <ClInclude Include="..\..\dmc\dlls\soundent.h" />
+    <ClInclude Include="..\..\dmc\dlls\spectator.h" />
+    <ClInclude Include="..\..\dmc\dlls\teamplay_gamerules.h" />
+    <ClInclude Include="..\..\dmc\dlls\threewave_gamerules.h" />
+    <ClInclude Include="..\..\dmc\dlls\trains.h" />
+    <ClInclude Include="..\..\dmc\dlls\util.h" />
+    <ClInclude Include="..\..\dmc\dlls\vector.h" />
+    <ClInclude Include="..\..\dmc\dlls\weapons.h" />
+    <ClInclude Include="..\..\dmc\pm_shared\pm_debug.h" />
+    <ClInclude Include="..\..\dmc\pm_shared\pm_defs.h" />
+    <ClInclude Include="..\..\dmc\pm_shared\pm_info.h" />
+    <ClInclude Include="..\..\dmc\pm_shared\pm_materials.h" />
+    <ClInclude Include="..\..\dmc\pm_shared\pm_movevars.h" />
+    <ClInclude Include="..\..\dmc\pm_shared\pm_shared.h" />
+    <ClInclude Include="..\..\game_shared\voice_gamemgr.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{6C5EBEF4-40AE-4167-B3D5-26F0AB47E382}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>dmcdll</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+    <TargetName>dmc</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+    <TargetName>dmc</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;QUIVER;VOXEL;QUAKE2;VALVE_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\public;..\..\game_shared;..\..\dmc\dlls;..\..\engine;..\..\common;..\..\dmc\pm_shared;..\..\dmc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>$(ProjectDir)..\..\dmc\dlls\dmc.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;QUIVER;VOXEL;QUAKE2;VALVE_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\public;..\..\game_shared;..\..\dmc\dlls;..\..\engine;..\..\common;..\..\dmc\pm_shared;..\..\dmc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <ModuleDefinitionFile>$(ProjectDir)..\..\dmc\dlls\dmc.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/dmcdll.vcxproj.filters
+++ b/projects/vs2019/dmcdll.vcxproj.filters
@@ -1,0 +1,333 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\dmc">
+      <UniqueIdentifier>{c5ff4571-ca04-4e1f-80e9-a19506da02f2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\dmc\dlls">
+      <UniqueIdentifier>{5dec4dc2-32bf-42c2-b2f2-d1d51e0570ac}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\dmc\pm_shared">
+      <UniqueIdentifier>{bdf7ca1b-850d-4ba7-bd67-415aa43b6253}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\game_shared">
+      <UniqueIdentifier>{cb42fc3a-444b-4840-8de8-b4130a14d9d6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\dmc">
+      <UniqueIdentifier>{91a827c4-689d-46e4-8f96-ace43cdbc9c9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\dmc\dlls">
+      <UniqueIdentifier>{cc570f9a-1abf-41cc-b5ba-e0b498ca4b81}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\dmc\pm_shared">
+      <UniqueIdentifier>{6de9e702-afbc-41de-a5a3-2f8dfd99d18b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\game_shared">
+      <UniqueIdentifier>{3546bbd0-6019-4fd3-b958-359c4bf3a897}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_Shared Weapons">
+      <UniqueIdentifier>{c7a2ed7b-dc8c-4df5-9fb9-d37c542058af}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_Shared Weapons\dmc">
+      <UniqueIdentifier>{646a6534-4acb-4aa0-8341-17a34671b226}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_Shared Weapons\dmc\dlls">
+      <UniqueIdentifier>{f1606514-06e0-4c6e-b751-4c0b6bf1e171}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\dmc\dlls\quake_weapons_all.cpp">
+      <Filter>Source Files\_Shared Weapons\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\quake_gun.cpp">
+      <Filter>Source Files\_Shared Weapons\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\player.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\animating.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\animation.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\bmodels.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\buttons.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\cbase.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\client.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\combat.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\doors.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\effects.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\explode.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\func_break.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\func_tank.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\game.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\gamerules.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\globals.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\h_ai.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\h_export.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\lights.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\maprules.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\monsters.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\monsterstate.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\multiplay_gamerules.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\nodes.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\observer.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\pathcorner.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\plane.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\plats.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\pm_shared\pm_shared.c">
+      <Filter>Source Files\dmc\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\pm_shared\pm_debug.c">
+      <Filter>Source Files\dmc\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\pm_shared\pm_math.c">
+      <Filter>Source Files\dmc\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\util.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\quake_items.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\quake_nail.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\quake_player.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\quake_rocket.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\schedule.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\singleplay_gamerules.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\skill.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\sound.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\spectator.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\subs.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\teamplay_gamerules.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\threewave_gamerules.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\triggers.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\voice_gamemgr.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\weapons.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dmc\dlls\world.cpp">
+      <Filter>Source Files\dmc\dlls</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\dmc\dlls\player.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\activity.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\activitymap.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\animation.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\basemonster.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\cbase.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\cdll_dll.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\client.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\decals.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\defaultai.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\doors.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\effects.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\enginecallback.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\explode.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\extdll.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\func_break.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\gamerules.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\items.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\monsterevent.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\monsters.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\nodes.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\plane.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\pm_shared\pm_shared.h">
+      <Filter>Header Files\dmc\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\pm_shared\pm_debug.h">
+      <Filter>Header Files\dmc\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\pm_shared\pm_defs.h">
+      <Filter>Header Files\dmc\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\pm_shared\pm_info.h">
+      <Filter>Header Files\dmc\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\pm_shared\pm_materials.h">
+      <Filter>Header Files\dmc\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\pm_shared\pm_movevars.h">
+      <Filter>Header Files\dmc\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\weapons.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\quake_gun.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\saverestore.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\schedule.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\scripted.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\scriptevent.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\skill.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\soundent.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\spectator.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\teamplay_gamerules.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\threewave_gamerules.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\trains.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\util.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dmc\dlls\vector.h">
+      <Filter>Header Files\dmc\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\game_shared\voice_gamemgr.h">
+      <Filter>Header Files\game_shared</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/hl_cdll.vcxproj
+++ b/projects/vs2019/hl_cdll.vcxproj
@@ -1,0 +1,229 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{DC1DD765-CFEB-47DA-A2EA-9F1E20A24272}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>hl_cdll</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <TargetName>client</TargetName>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <TargetName>client</TargetName>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;CLIENT_DLL;CLIENT_WEAPONS;HL_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\..\dlls;..\..\cl_dll;..\..\public;..\..\common;..\..\pm_shared;..\..\engine;..\..\utils\vgui\include;..\..\game_shared;..\..\external;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>..\..\utils\vgui\lib\win32_vc6\vgui.lib;wsock32.lib;..\..\lib\public\sdl2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <BaseAddress>
+      </BaseAddress>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;CLIENT_DLL;CLIENT_WEAPONS;HL_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\..\dlls;..\..\cl_dll;..\..\public;..\..\common;..\..\pm_shared;..\..\engine;..\..\utils\vgui\include;..\..\game_shared;..\..\external;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>..\..\utils\vgui\lib\win32_vc6\vgui.lib;wsock32.lib;..\..\lib\public\sdl2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <BaseAddress>
+      </BaseAddress>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\cl_dll\ammo.cpp" />
+    <ClCompile Include="..\..\cl_dll\ammohistory.cpp" />
+    <ClCompile Include="..\..\cl_dll\ammo_secondary.cpp" />
+    <ClCompile Include="..\..\cl_dll\battery.cpp" />
+    <ClCompile Include="..\..\cl_dll\cdll_int.cpp" />
+    <ClCompile Include="..\..\cl_dll\com_weapons.cpp" />
+    <ClCompile Include="..\..\cl_dll\death.cpp" />
+    <ClCompile Include="..\..\cl_dll\demo.cpp" />
+    <ClCompile Include="..\..\cl_dll\entity.cpp" />
+    <ClCompile Include="..\..\cl_dll\events.cpp" />
+    <ClCompile Include="..\..\cl_dll\ev_common.cpp" />
+    <ClCompile Include="..\..\cl_dll\ev_hldm.cpp" />
+    <ClCompile Include="..\..\cl_dll\flashlight.cpp" />
+    <ClCompile Include="..\..\cl_dll\GameStudioModelRenderer.cpp" />
+    <ClCompile Include="..\..\cl_dll\geiger.cpp" />
+    <ClCompile Include="..\..\cl_dll\health.cpp" />
+    <ClCompile Include="..\..\cl_dll\hl\hl_baseentity.cpp" />
+    <ClCompile Include="..\..\cl_dll\hl\hl_events.cpp" />
+    <ClCompile Include="..\..\cl_dll\hl\hl_objects.cpp" />
+    <ClCompile Include="..\..\cl_dll\hl\hl_weapons.cpp" />
+    <ClCompile Include="..\..\cl_dll\hud.cpp" />
+    <ClCompile Include="..\..\cl_dll\hud_bench.cpp" />
+    <ClCompile Include="..\..\cl_dll\hud_benchtrace.cpp" />
+    <ClCompile Include="..\..\cl_dll\hud_msg.cpp" />
+    <ClCompile Include="..\..\cl_dll\hud_redraw.cpp" />
+    <ClCompile Include="..\..\cl_dll\hud_servers.cpp" />
+    <ClCompile Include="..\..\cl_dll\hud_spectator.cpp" />
+    <ClCompile Include="..\..\cl_dll\hud_update.cpp" />
+    <ClCompile Include="..\..\cl_dll\input.cpp" />
+    <ClCompile Include="..\..\cl_dll\inputw32.cpp" />
+    <ClCompile Include="..\..\cl_dll\interpolation.cpp" />
+    <ClCompile Include="..\..\cl_dll\in_camera.cpp" />
+    <ClCompile Include="..\..\cl_dll\menu.cpp" />
+    <ClCompile Include="..\..\cl_dll\message.cpp" />
+    <ClCompile Include="..\..\cl_dll\saytext.cpp" />
+    <ClCompile Include="..\..\cl_dll\statusbar.cpp" />
+    <ClCompile Include="..\..\cl_dll\status_icons.cpp" />
+    <ClCompile Include="..\..\cl_dll\StudioModelRenderer.cpp" />
+    <ClCompile Include="..\..\cl_dll\studio_util.cpp" />
+    <ClCompile Include="..\..\cl_dll\text_message.cpp" />
+    <ClCompile Include="..\..\cl_dll\train.cpp" />
+    <ClCompile Include="..\..\cl_dll\tri.cpp" />
+    <ClCompile Include="..\..\cl_dll\util.cpp" />
+    <ClCompile Include="..\..\cl_dll\vgui_ClassMenu.cpp" />
+    <ClCompile Include="..\..\cl_dll\vgui_ControlConfigPanel.cpp" />
+    <ClCompile Include="..\..\cl_dll\vgui_CustomObjects.cpp" />
+    <ClCompile Include="..\..\cl_dll\vgui_int.cpp" />
+    <ClCompile Include="..\..\cl_dll\vgui_MOTDWindow.cpp" />
+    <ClCompile Include="..\..\cl_dll\vgui_SchemeManager.cpp" />
+    <ClCompile Include="..\..\cl_dll\vgui_ScorePanel.cpp" />
+    <ClCompile Include="..\..\cl_dll\vgui_ServerBrowser.cpp" />
+    <ClCompile Include="..\..\cl_dll\vgui_SpectatorPanel.cpp" />
+    <ClCompile Include="..\..\cl_dll\vgui_TeamFortressViewport.cpp" />
+    <ClCompile Include="..\..\cl_dll\vgui_teammenu.cpp" />
+    <ClCompile Include="..\..\cl_dll\view.cpp" />
+    <ClCompile Include="..\..\cl_dll\voice_status.cpp" />
+    <ClCompile Include="..\..\common\parsemsg.cpp" />
+    <ClCompile Include="..\..\dlls\crossbow.cpp" />
+    <ClCompile Include="..\..\dlls\crowbar.cpp" />
+    <ClCompile Include="..\..\dlls\egon.cpp" />
+    <ClCompile Include="..\..\dlls\gauss.cpp" />
+    <ClCompile Include="..\..\dlls\handgrenade.cpp" />
+    <ClCompile Include="..\..\dlls\hornetgun.cpp" />
+    <ClCompile Include="..\..\dlls\mp5.cpp" />
+    <ClCompile Include="..\..\dlls\python.cpp" />
+    <ClCompile Include="..\..\dlls\rpg.cpp" />
+    <ClCompile Include="..\..\dlls\satchel.cpp" />
+    <ClCompile Include="..\..\dlls\shotgun.cpp" />
+    <ClCompile Include="..\..\dlls\squeakgrenade.cpp" />
+    <ClCompile Include="..\..\dlls\tripmine.cpp" />
+    <ClCompile Include="..\..\dlls\wpn_shared\hl_wpn_glock.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_checkbutton2.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_grid.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_helpers.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_listbox.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_loadtga.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_scrollbar2.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_slider2.cpp" />
+    <ClCompile Include="..\..\game_shared\voice_banmgr.cpp" />
+    <ClCompile Include="..\..\pm_shared\pm_debug.c" />
+    <ClCompile Include="..\..\pm_shared\pm_math.c" />
+    <ClCompile Include="..\..\pm_shared\pm_shared.c" />
+    <ClCompile Include="..\..\public\interface.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\cl_dll\ammo.h" />
+    <ClInclude Include="..\..\cl_dll\ammohistory.h" />
+    <ClInclude Include="..\..\cl_dll\camera.h" />
+    <ClInclude Include="..\..\cl_dll\cl_dll.h" />
+    <ClInclude Include="..\..\cl_dll\cl_util.h" />
+    <ClInclude Include="..\..\cl_dll\com_weapons.h" />
+    <ClInclude Include="..\..\cl_dll\demo.h" />
+    <ClInclude Include="..\..\cl_dll\eventscripts.h" />
+    <ClInclude Include="..\..\cl_dll\ev_hldm.h" />
+    <ClInclude Include="..\..\cl_dll\GameStudioModelRenderer.h" />
+    <ClInclude Include="..\..\cl_dll\health.h" />
+    <ClInclude Include="..\..\cl_dll\hud.h" />
+    <ClInclude Include="..\..\cl_dll\hud_servers.h" />
+    <ClInclude Include="..\..\cl_dll\hud_servers_priv.h" />
+    <ClInclude Include="..\..\cl_dll\hud_spectator.h" />
+    <ClInclude Include="..\..\cl_dll\interpolation.h" />
+    <ClInclude Include="..\..\cl_dll\in_defs.h" />
+    <ClInclude Include="..\..\cl_dll\kbutton.h" />
+    <ClInclude Include="..\..\cl_dll\StudioModelRenderer.h" />
+    <ClInclude Include="..\..\cl_dll\tri.h" />
+    <ClInclude Include="..\..\cl_dll\util_vector.h" />
+    <ClInclude Include="..\..\cl_dll\vgui_ControlConfigPanel.h" />
+    <ClInclude Include="..\..\cl_dll\vgui_int.h" />
+    <ClInclude Include="..\..\cl_dll\vgui_SchemeManager.h" />
+    <ClInclude Include="..\..\cl_dll\vgui_ScorePanel.h" />
+    <ClInclude Include="..\..\cl_dll\vgui_ServerBrowser.h" />
+    <ClInclude Include="..\..\cl_dll\vgui_SpectatorPanel.h" />
+    <ClInclude Include="..\..\cl_dll\view.h" />
+    <ClInclude Include="..\..\cl_dll\wrect.h" />
+    <ClInclude Include="..\..\common\parsemsg.h" />
+    <ClInclude Include="..\..\game_shared\vgui_scrollbar2.h" />
+    <ClInclude Include="..\..\game_shared\vgui_slider2.h" />
+    <ClInclude Include="..\..\game_shared\voice_banmgr.h" />
+    <ClInclude Include="..\..\game_shared\voice_status.h" />
+    <ClInclude Include="..\..\pm_shared\pm_debug.h" />
+    <ClInclude Include="..\..\pm_shared\pm_defs.h" />
+    <ClInclude Include="..\..\pm_shared\pm_info.h" />
+    <ClInclude Include="..\..\pm_shared\pm_materials.h" />
+    <ClInclude Include="..\..\pm_shared\pm_movevars.h" />
+    <ClInclude Include="..\..\pm_shared\pm_shared.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Library Include="..\..\lib\public\game_controls.lib" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/hl_cdll.vcxproj.filters
+++ b/projects/vs2019/hl_cdll.vcxproj.filters
@@ -1,0 +1,435 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\cl_dll">
+      <UniqueIdentifier>{01b8d565-8fa1-4999-8cb6-01da5dd1e555}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\common">
+      <UniqueIdentifier>{6887a889-19a5-42f7-8af9-2af4b64cbf2b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\pm_shared">
+      <UniqueIdentifier>{7d8ce8c9-fed8-42ee-9ba0-73d0fee6006a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\game_shared">
+      <UniqueIdentifier>{83318ea3-5019-4d8a-a9f9-4922cdb1c9bb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\cl_dll">
+      <UniqueIdentifier>{95dcdae3-b427-4517-a477-bfa2583b2e1f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\common">
+      <UniqueIdentifier>{54679c20-fece-4cb1-bef2-017d30f31af0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\pm_shared">
+      <UniqueIdentifier>{fb64b597-8c31-4391-b259-6121f67bbccb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\game_shared">
+      <UniqueIdentifier>{dfaa6b94-3821-41ff-a9c2-ef94fbb0d7d1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\public">
+      <UniqueIdentifier>{c053705f-05f3-4d16-ab13-80bfa84cbe75}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_hl">
+      <UniqueIdentifier>{f033f23a-ab54-411c-bebf-72d10839418e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_hl\dlls">
+      <UniqueIdentifier>{a2469e54-cb56-4161-b6b1-55c9d93676c1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_hl\dlls\wpn_shared">
+      <UniqueIdentifier>{a46a0ff1-e7ad-43c4-afb8-6c93e71803a1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_hl\cl_dll">
+      <UniqueIdentifier>{5bff06ec-c232-4dd2-8642-4e2ce64f31ef}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_hl\cl_dll\hl">
+      <UniqueIdentifier>{bd9d5958-4e67-4bff-bbd8-6ba6dfcdb720}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\dlls\crossbow.cpp">
+      <Filter>Source Files\_hl\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\crowbar.cpp">
+      <Filter>Source Files\_hl\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\egon.cpp">
+      <Filter>Source Files\_hl\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\ev_hldm.cpp">
+      <Filter>Source Files\_hl\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\gauss.cpp">
+      <Filter>Source Files\_hl\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\handgrenade.cpp">
+      <Filter>Source Files\_hl\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\hl\hl_weapons.cpp">
+      <Filter>Source Files\_hl\cl_dll\hl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\hl\hl_baseentity.cpp">
+      <Filter>Source Files\_hl\cl_dll\hl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\hl\hl_events.cpp">
+      <Filter>Source Files\_hl\cl_dll\hl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\hl\hl_objects.cpp">
+      <Filter>Source Files\_hl\cl_dll\hl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\wpn_shared\hl_wpn_glock.cpp">
+      <Filter>Source Files\_hl\dlls\wpn_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\squeakgrenade.cpp">
+      <Filter>Source Files\_hl\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\hornetgun.cpp">
+      <Filter>Source Files\_hl\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\mp5.cpp">
+      <Filter>Source Files\_hl\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\python.cpp">
+      <Filter>Source Files\_hl\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\rpg.cpp">
+      <Filter>Source Files\_hl\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\satchel.cpp">
+      <Filter>Source Files\_hl\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\shotgun.cpp">
+      <Filter>Source Files\_hl\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\tripmine.cpp">
+      <Filter>Source Files\_hl\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\death.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\ammo.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\ammo_secondary.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\ammohistory.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\battery.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\cdll_int.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\com_weapons.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\message.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\demo.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\entity.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\ev_common.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\events.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\flashlight.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\GameStudioModelRenderer.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\geiger.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\health.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\hud.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\hud_bench.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\hud_benchtrace.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\hud_msg.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\hud_redraw.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\hud_servers.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\hud_spectator.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\hud_update.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\in_camera.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\input.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\inputw32.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\interpolation.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\menu.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\common\parsemsg.cpp">
+      <Filter>Source Files\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\pm_shared\pm_shared.c">
+      <Filter>Source Files\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\pm_shared\pm_debug.c">
+      <Filter>Source Files\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\pm_shared\pm_math.c">
+      <Filter>Source Files\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\util.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\saytext.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\status_icons.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\statusbar.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\studio_util.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\StudioModelRenderer.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\text_message.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\train.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\tri.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_checkbutton2.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\vgui_CustomObjects.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\vgui_ClassMenu.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\vgui_ControlConfigPanel.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_grid.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_helpers.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\vgui_int.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_loadtga.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_listbox.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\vgui_MOTDWindow.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\vgui_SchemeManager.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\vgui_ScorePanel.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\voice_banmgr.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_scrollbar2.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_slider2.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\view.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\vgui_ServerBrowser.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\vgui_SpectatorPanel.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\vgui_TeamFortressViewport.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\vgui_teammenu.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\cl_dll\voice_status.cpp">
+      <Filter>Source Files\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\public\interface.cpp">
+      <Filter>Source Files\public</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\cl_dll\kbutton.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\ammo.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\ammohistory.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\camera.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\cl_dll.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\cl_util.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\com_weapons.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\demo.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\ev_hldm.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\eventscripts.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\GameStudioModelRenderer.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\health.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\hud.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\hud_servers.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\hud_servers_priv.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\hud_spectator.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\in_defs.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\interpolation.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\common\parsemsg.h">
+      <Filter>Header Files\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\pm_shared\pm_shared.h">
+      <Filter>Header Files\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\pm_shared\pm_debug.h">
+      <Filter>Header Files\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\pm_shared\pm_defs.h">
+      <Filter>Header Files\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\pm_shared\pm_info.h">
+      <Filter>Header Files\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\pm_shared\pm_materials.h">
+      <Filter>Header Files\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\pm_shared\pm_movevars.h">
+      <Filter>Header Files\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\vgui_ScorePanel.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\StudioModelRenderer.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\tri.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\util_vector.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\vgui_ControlConfigPanel.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\vgui_int.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\vgui_SchemeManager.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\game_shared\vgui_slider2.h">
+      <Filter>Header Files\game_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\game_shared\voice_status.h">
+      <Filter>Header Files\game_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\game_shared\vgui_scrollbar2.h">
+      <Filter>Header Files\game_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\game_shared\voice_banmgr.h">
+      <Filter>Header Files\game_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\wrect.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\vgui_ServerBrowser.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\vgui_SpectatorPanel.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\cl_dll\view.h">
+      <Filter>Header Files\cl_dll</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Library Include="..\..\lib\public\game_controls.lib" />
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/hldll.vcxproj
+++ b/projects/vs2019/hldll.vcxproj
@@ -1,0 +1,246 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{69DDADC0-97F4-419E-86EB-C91781A0D2E0}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>hldll</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+    <TargetName>hl</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+    <TargetName>hl</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;QUIVER;VOXEL;QUAKE2;VALVE_DLL;CLIENT_WEAPONS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <AdditionalIncludeDirectories>..\..\dlls;..\..\engine;..\..\common;..\..\pm_shared;..\..\game_shared;..\..\public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>$(ProjectDir)..\..\dlls\hl.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;QUIVER;VOXEL;QUAKE2;VALVE_DLL;CLIENT_WEAPONS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\dlls;..\..\engine;..\..\common;..\..\pm_shared;..\..\game_shared;..\..\public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <ModuleDefinitionFile>$(ProjectDir)..\..\dlls\hl.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\dlls\aflock.cpp" />
+    <ClCompile Include="..\..\dlls\agrunt.cpp" />
+    <ClCompile Include="..\..\dlls\airtank.cpp" />
+    <ClCompile Include="..\..\dlls\animating.cpp" />
+    <ClCompile Include="..\..\dlls\animation.cpp" />
+    <ClCompile Include="..\..\dlls\apache.cpp" />
+    <ClCompile Include="..\..\dlls\barnacle.cpp" />
+    <ClCompile Include="..\..\dlls\barney.cpp" />
+    <ClCompile Include="..\..\dlls\bigmomma.cpp" />
+    <ClCompile Include="..\..\dlls\bloater.cpp" />
+    <ClCompile Include="..\..\dlls\bmodels.cpp" />
+    <ClCompile Include="..\..\dlls\bullsquid.cpp" />
+    <ClCompile Include="..\..\dlls\buttons.cpp" />
+    <ClCompile Include="..\..\dlls\cbase.cpp" />
+    <ClCompile Include="..\..\dlls\client.cpp" />
+    <ClCompile Include="..\..\dlls\combat.cpp" />
+    <ClCompile Include="..\..\dlls\controller.cpp" />
+    <ClCompile Include="..\..\dlls\crossbow.cpp" />
+    <ClCompile Include="..\..\dlls\crowbar.cpp" />
+    <ClCompile Include="..\..\dlls\defaultai.cpp" />
+    <ClCompile Include="..\..\dlls\doors.cpp" />
+    <ClCompile Include="..\..\dlls\effects.cpp" />
+    <ClCompile Include="..\..\dlls\egon.cpp" />
+    <ClCompile Include="..\..\dlls\explode.cpp" />
+    <ClCompile Include="..\..\dlls\flyingmonster.cpp" />
+    <ClCompile Include="..\..\dlls\func_break.cpp" />
+    <ClCompile Include="..\..\dlls\func_tank.cpp" />
+    <ClCompile Include="..\..\dlls\game.cpp" />
+    <ClCompile Include="..\..\dlls\gamerules.cpp" />
+    <ClCompile Include="..\..\dlls\gargantua.cpp" />
+    <ClCompile Include="..\..\dlls\gauss.cpp" />
+    <ClCompile Include="..\..\dlls\genericmonster.cpp" />
+    <ClCompile Include="..\..\dlls\ggrenade.cpp" />
+    <ClCompile Include="..\..\dlls\globals.cpp" />
+    <ClCompile Include="..\..\dlls\gman.cpp" />
+    <ClCompile Include="..\..\dlls\handgrenade.cpp" />
+    <ClCompile Include="..\..\dlls\hassassin.cpp" />
+    <ClCompile Include="..\..\dlls\headcrab.cpp" />
+    <ClCompile Include="..\..\dlls\healthkit.cpp" />
+    <ClCompile Include="..\..\dlls\hgrunt.cpp" />
+    <ClCompile Include="..\..\dlls\hornet.cpp" />
+    <ClCompile Include="..\..\dlls\hornetgun.cpp" />
+    <ClCompile Include="..\..\dlls\houndeye.cpp" />
+    <ClCompile Include="..\..\dlls\h_ai.cpp" />
+    <ClCompile Include="..\..\dlls\h_battery.cpp" />
+    <ClCompile Include="..\..\dlls\h_cine.cpp" />
+    <ClCompile Include="..\..\dlls\h_cycler.cpp" />
+    <ClCompile Include="..\..\dlls\h_export.cpp" />
+    <ClCompile Include="..\..\dlls\ichthyosaur.cpp" />
+    <ClCompile Include="..\..\dlls\islave.cpp" />
+    <ClCompile Include="..\..\dlls\items.cpp" />
+    <ClCompile Include="..\..\dlls\leech.cpp" />
+    <ClCompile Include="..\..\dlls\lights.cpp" />
+    <ClCompile Include="..\..\dlls\maprules.cpp" />
+    <ClCompile Include="..\..\dlls\monstermaker.cpp" />
+    <ClCompile Include="..\..\dlls\monsters.cpp" />
+    <ClCompile Include="..\..\dlls\monsterstate.cpp" />
+    <ClCompile Include="..\..\dlls\mortar.cpp" />
+    <ClCompile Include="..\..\dlls\mp5.cpp" />
+    <ClCompile Include="..\..\dlls\multiplay_gamerules.cpp" />
+    <ClCompile Include="..\..\dlls\nihilanth.cpp" />
+    <ClCompile Include="..\..\dlls\nodes.cpp" />
+    <ClCompile Include="..\..\dlls\observer.cpp" />
+    <ClCompile Include="..\..\dlls\osprey.cpp" />
+    <ClCompile Include="..\..\dlls\pathcorner.cpp" />
+    <ClCompile Include="..\..\dlls\plane.cpp" />
+    <ClCompile Include="..\..\dlls\plats.cpp" />
+    <ClCompile Include="..\..\dlls\player.cpp" />
+    <ClCompile Include="..\..\dlls\python.cpp" />
+    <ClCompile Include="..\..\dlls\rat.cpp" />
+    <ClCompile Include="..\..\dlls\roach.cpp" />
+    <ClCompile Include="..\..\dlls\rpg.cpp" />
+    <ClCompile Include="..\..\dlls\satchel.cpp" />
+    <ClCompile Include="..\..\dlls\schedule.cpp" />
+    <ClCompile Include="..\..\dlls\scientist.cpp" />
+    <ClCompile Include="..\..\dlls\scripted.cpp" />
+    <ClCompile Include="..\..\dlls\shotgun.cpp" />
+    <ClCompile Include="..\..\dlls\singleplay_gamerules.cpp" />
+    <ClCompile Include="..\..\dlls\skill.cpp" />
+    <ClCompile Include="..\..\dlls\sound.cpp" />
+    <ClCompile Include="..\..\dlls\soundent.cpp" />
+    <ClCompile Include="..\..\dlls\spectator.cpp" />
+    <ClCompile Include="..\..\dlls\squadmonster.cpp" />
+    <ClCompile Include="..\..\dlls\squeakgrenade.cpp" />
+    <ClCompile Include="..\..\dlls\subs.cpp" />
+    <ClCompile Include="..\..\dlls\talkmonster.cpp" />
+    <ClCompile Include="..\..\dlls\teamplay_gamerules.cpp" />
+    <ClCompile Include="..\..\dlls\tempmonster.cpp" />
+    <ClCompile Include="..\..\dlls\tentacle.cpp" />
+    <ClCompile Include="..\..\dlls\triggers.cpp" />
+    <ClCompile Include="..\..\dlls\tripmine.cpp" />
+    <ClCompile Include="..\..\dlls\turret.cpp" />
+    <ClCompile Include="..\..\dlls\util.cpp" />
+    <ClCompile Include="..\..\dlls\weapons.cpp" />
+    <ClCompile Include="..\..\dlls\world.cpp" />
+    <ClCompile Include="..\..\dlls\wpn_shared\hl_wpn_glock.cpp" />
+    <ClCompile Include="..\..\dlls\xen.cpp" />
+    <ClCompile Include="..\..\dlls\zombie.cpp" />
+    <ClCompile Include="..\..\game_shared\voice_gamemgr.cpp" />
+    <ClCompile Include="..\..\pm_shared\pm_debug.c" />
+    <ClCompile Include="..\..\pm_shared\pm_math.c" />
+    <ClCompile Include="..\..\pm_shared\pm_shared.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\dlls\activity.h" />
+    <ClInclude Include="..\..\dlls\activitymap.h" />
+    <ClInclude Include="..\..\dlls\animation.h" />
+    <ClInclude Include="..\..\dlls\basemonster.h" />
+    <ClInclude Include="..\..\dlls\cbase.h" />
+    <ClInclude Include="..\..\dlls\cdll_dll.h" />
+    <ClInclude Include="..\..\dlls\client.h" />
+    <ClInclude Include="..\..\dlls\decals.h" />
+    <ClInclude Include="..\..\dlls\defaultai.h" />
+    <ClInclude Include="..\..\dlls\doors.h" />
+    <ClInclude Include="..\..\dlls\effects.h" />
+    <ClInclude Include="..\..\dlls\enginecallback.h" />
+    <ClInclude Include="..\..\dlls\explode.h" />
+    <ClInclude Include="..\..\dlls\extdll.h" />
+    <ClInclude Include="..\..\dlls\flyingmonster.h" />
+    <ClInclude Include="..\..\dlls\func_break.h" />
+    <ClInclude Include="..\..\dlls\gamerules.h" />
+    <ClInclude Include="..\..\dlls\hornet.h" />
+    <ClInclude Include="..\..\dlls\items.h" />
+    <ClInclude Include="..\..\dlls\monsterevent.h" />
+    <ClInclude Include="..\..\dlls\monsters.h" />
+    <ClInclude Include="..\..\dlls\nodes.h" />
+    <ClInclude Include="..\..\dlls\plane.h" />
+    <ClInclude Include="..\..\dlls\player.h" />
+    <ClInclude Include="..\..\dlls\saverestore.h" />
+    <ClInclude Include="..\..\dlls\schedule.h" />
+    <ClInclude Include="..\..\dlls\scripted.h" />
+    <ClInclude Include="..\..\dlls\scriptevent.h" />
+    <ClInclude Include="..\..\dlls\skill.h" />
+    <ClInclude Include="..\..\dlls\soundent.h" />
+    <ClInclude Include="..\..\dlls\spectator.h" />
+    <ClInclude Include="..\..\dlls\squadmonster.h" />
+    <ClInclude Include="..\..\dlls\talkmonster.h" />
+    <ClInclude Include="..\..\dlls\teamplay_gamerules.h" />
+    <ClInclude Include="..\..\dlls\trains.h" />
+    <ClInclude Include="..\..\dlls\util.h" />
+    <ClInclude Include="..\..\dlls\vector.h" />
+    <ClInclude Include="..\..\dlls\weapons.h" />
+    <ClInclude Include="..\..\engine\eiface.h" />
+    <ClInclude Include="..\..\pm_shared\pm_debug.h" />
+    <ClInclude Include="..\..\pm_shared\pm_defs.h" />
+    <ClInclude Include="..\..\pm_shared\pm_info.h" />
+    <ClInclude Include="..\..\pm_shared\pm_materials.h" />
+    <ClInclude Include="..\..\pm_shared\pm_movevars.h" />
+    <ClInclude Include="..\..\pm_shared\pm_shared.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/hldll.vcxproj.filters
+++ b/projects/vs2019/hldll.vcxproj.filters
@@ -1,0 +1,483 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\dlls">
+      <UniqueIdentifier>{a59f65b1-455f-459d-bc2a-75775255cd5c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\dlls\wpn_shared">
+      <UniqueIdentifier>{000b311c-d555-467e-b6cb-5e669fb8c45e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\pm_shared">
+      <UniqueIdentifier>{7f184267-1d16-4bbc-9212-a804fcd04e6a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\game_shared">
+      <UniqueIdentifier>{9cd951c6-53c4-4c79-826f-13ac1af8a8b6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\dlls">
+      <UniqueIdentifier>{e3b69fef-bfa6-4270-8280-f2b25793ac4e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\engine">
+      <UniqueIdentifier>{b85e935a-5cc8-482d-b85f-6cdaa3452ccb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\pm_shared">
+      <UniqueIdentifier>{37941113-16fa-4ce0-9bdd-a72a1ced8902}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\dlls\aflock.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\agrunt.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\airtank.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\animating.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\animation.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\apache.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\barnacle.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\barney.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\bigmomma.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\bloater.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\bmodels.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\bullsquid.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\buttons.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\cbase.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\client.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\combat.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\controller.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\crossbow.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\crowbar.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\defaultai.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\gman.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\doors.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\effects.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\egon.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\explode.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\flyingmonster.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\func_break.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\func_tank.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\game.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\gamerules.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\gargantua.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\gauss.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\genericmonster.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\ggrenade.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\globals.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\h_ai.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\h_battery.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\h_cine.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\h_cycler.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\h_export.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\handgrenade.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\hassassin.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\headcrab.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\healthkit.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\hgrunt.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\wpn_shared\hl_wpn_glock.cpp">
+      <Filter>Source Files\dlls\wpn_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\monstermaker.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\hornet.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\hornetgun.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\houndeye.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\ichthyosaur.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\islave.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\items.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\leech.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\lights.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\maprules.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\player.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\monsters.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\monsterstate.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\mortar.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\mp5.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\multiplay_gamerules.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\nihilanth.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\nodes.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\observer.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\osprey.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\pathcorner.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\plane.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\plats.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\pm_shared\pm_shared.c">
+      <Filter>Source Files\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\pm_shared\pm_debug.c">
+      <Filter>Source Files\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\pm_shared\pm_math.c">
+      <Filter>Source Files\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\python.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\rat.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\roach.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\rpg.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\satchel.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\schedule.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\scientist.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\scripted.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\shotgun.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\singleplay_gamerules.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\skill.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\sound.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\soundent.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\spectator.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\squadmonster.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\squeakgrenade.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\subs.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\talkmonster.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\teamplay_gamerules.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\tempmonster.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\tentacle.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\triggers.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\tripmine.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\turret.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\util.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\voice_gamemgr.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\zombie.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\weapons.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\world.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\dlls\xen.cpp">
+      <Filter>Source Files\dlls</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\dlls\doors.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\activity.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\activitymap.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\animation.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\basemonster.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\cbase.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\cdll_dll.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\client.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\decals.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\defaultai.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\effects.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\engine\eiface.h">
+      <Filter>Header Files\engine</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\hornet.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\enginecallback.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\explode.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\extdll.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\flyingmonster.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\func_break.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\gamerules.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\player.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\items.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\monsterevent.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\monsters.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\nodes.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\plane.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\pm_shared\pm_shared.h">
+      <Filter>Header Files\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\pm_shared\pm_debug.h">
+      <Filter>Header Files\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\pm_shared\pm_defs.h">
+      <Filter>Header Files\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\pm_shared\pm_info.h">
+      <Filter>Header Files\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\pm_shared\pm_materials.h">
+      <Filter>Header Files\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\pm_shared\pm_movevars.h">
+      <Filter>Header Files\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\weapons.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\saverestore.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\schedule.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\scripted.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\scriptevent.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\skill.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\soundent.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\spectator.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\squadmonster.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\talkmonster.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\teamplay_gamerules.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\trains.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\util.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\dlls\vector.h">
+      <Filter>Header Files\dlls</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/light.vcxproj
+++ b/projects/vs2019/light.vcxproj
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\bspfile.c" />
+    <ClCompile Include="..\..\utils\common\cmdlib.c" />
+    <ClCompile Include="..\..\utils\common\mathlib.c" />
+    <ClCompile Include="..\..\utils\common\scriplib.c" />
+    <ClCompile Include="..\..\utils\common\threads.c" />
+    <ClCompile Include="..\..\utils\light\light.c" />
+    <ClCompile Include="..\..\utils\light\ltface.c" />
+    <ClCompile Include="..\..\utils\light\trace.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\light\light.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{1D9A402B-C7AB-4DAA-AD3F-42195F283E64}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>bspinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/light.vcxproj.filters
+++ b/projects/vs2019/light.vcxproj.filters
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{d5586ccb-fc7d-4e19-8bde-8656f3036ed7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{23430839-825c-42f8-87f8-5ae8dbcbb612}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\common">
+      <UniqueIdentifier>{9e2cd4d4-3990-41a2-ae01-1cdcaeb123b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\light">
+      <UniqueIdentifier>{63245e01-3884-4650-b2a4-90c672eb89e9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\light">
+      <UniqueIdentifier>{b9529791-81ac-4e1b-86b7-e3ae05d40193}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\threads.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\bspfile.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\cmdlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\mathlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\scriplib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\light\trace.c">
+      <Filter>Source Files\utils\light</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\light\light.c">
+      <Filter>Source Files\utils\light</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\light\ltface.c">
+      <Filter>Source Files\utils\light</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\light\light.h">
+      <Filter>Header Files\utils\light</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/makefont.vcxproj
+++ b/projects/vs2019/makefont.vcxproj
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\cmdlib.c" />
+    <ClCompile Include="..\..\utils\common\wadlib.c" />
+    <ClCompile Include="..\..\utils\makefont\makefont.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\cmdlib.h" />
+    <ClInclude Include="..\..\utils\common\wadlib.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{C47ACACA-7DA4-4741-A287-9215309949E7}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>bspinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../common;../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../common;../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/makefont.vcxproj.filters
+++ b/projects/vs2019/makefont.vcxproj.filters
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{d5586ccb-fc7d-4e19-8bde-8656f3036ed7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{23430839-825c-42f8-87f8-5ae8dbcbb612}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\common">
+      <UniqueIdentifier>{b9529791-81ac-4e1b-86b7-e3ae05d40193}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\common">
+      <UniqueIdentifier>{9e2cd4d4-3990-41a2-ae01-1cdcaeb123b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\makefont">
+      <UniqueIdentifier>{673592e5-697a-4bb6-b06b-8104dcc2c470}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\wadlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\cmdlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\makefont\makefont.cpp">
+      <Filter>Source Files\utils\makefont</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\wadlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\cmdlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/makels.vcxproj
+++ b/projects/vs2019/makels.vcxproj
@@ -1,0 +1,92 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\makels\makels.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{8D9315B8-D428-411B-A60F-6AFD3CE0A687}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>bspinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>
+      </AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>
+      </AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/makels.vcxproj.filters
+++ b/projects/vs2019/makels.vcxproj.filters
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{d5586ccb-fc7d-4e19-8bde-8656f3036ed7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\makels">
+      <UniqueIdentifier>{63245e01-3884-4650-b2a4-90c672eb89e9}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\makels\makels.cpp">
+      <Filter>Source Files\utils\makels</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/mdlviewer.vcxproj
+++ b/projects/vs2019/mdlviewer.vcxproj
@@ -1,0 +1,104 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\mathlib.c" />
+    <ClCompile Include="..\..\utils\mdlviewer\mdlviewer.cpp" />
+    <ClCompile Include="..\..\utils\mdlviewer\studio_render.cpp" />
+    <ClCompile Include="..\..\utils\mdlviewer\studio_utils.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\mathlib.h" />
+    <ClInclude Include="..\..\utils\mdlviewer\mdlviewer.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\utils\mdlviewer\readme.txt" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{348EA74B-9E7E-4F35-9474-69A5DB1B5A42}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>bspinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common;../../common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>opengl32.lib;glu32.lib;..\..\ext\glut32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common;../../common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>opengl32.lib;glu32.lib;..\..\ext\glut32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/mdlviewer.vcxproj.filters
+++ b/projects/vs2019/mdlviewer.vcxproj.filters
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{d5586ccb-fc7d-4e19-8bde-8656f3036ed7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{23430839-825c-42f8-87f8-5ae8dbcbb612}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\common">
+      <UniqueIdentifier>{b9529791-81ac-4e1b-86b7-e3ae05d40193}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\common">
+      <UniqueIdentifier>{9e2cd4d4-3990-41a2-ae01-1cdcaeb123b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\mdlviewer">
+      <UniqueIdentifier>{7906402f-88d4-4690-a65a-bc8b7c7fe8a0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\mdlviewer">
+      <UniqueIdentifier>{a2b18871-ad87-49ac-8bfd-23c47a207fa5}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\mathlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\mdlviewer\studio_utils.cpp">
+      <Filter>Source Files\utils\mdlviewer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\mdlviewer\mdlviewer.cpp">
+      <Filter>Source Files\utils\mdlviewer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\mdlviewer\studio_render.cpp">
+      <Filter>Source Files\utils\mdlviewer</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\mdlviewer\mdlviewer.h">
+      <Filter>Header Files\utils\mdlviewer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\mathlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\utils\mdlviewer\readme.txt" />
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/mkmovie.vcxproj
+++ b/projects/vs2019/mkmovie.vcxproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\mkmovie\mkmovie.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\cmdlib.h" />
+    <ClInclude Include="..\..\utils\common\movie.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{67FAB994-BEE5-4537-8E00-60259F66F654}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>bspinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/mkmovie.vcxproj.filters
+++ b/projects/vs2019/mkmovie.vcxproj.filters
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{d5586ccb-fc7d-4e19-8bde-8656f3036ed7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{23430839-825c-42f8-87f8-5ae8dbcbb612}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\common">
+      <UniqueIdentifier>{b9529791-81ac-4e1b-86b7-e3ae05d40193}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\mkmovie">
+      <UniqueIdentifier>{62158a60-3771-4525-8b2c-953f323849d8}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\mkmovie\mkmovie.c">
+      <Filter>Source Files\utils\mkmovie</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\movie.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\cmdlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/procinfo.vcxproj
+++ b/projects/vs2019/procinfo.vcxproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{2DE8C1AF-56AE-4B99-8AA5-BEDBF33D6216}</ProjectGuid>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <Keyword>ManagedCProj</Keyword>
+    <RootNamespace>procinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>attrib -r ..\..\utils\procinfo\lib\win32_vc6\procinfo.lib
+copy $(TargetPath) ..\..\utils\procinfo\lib\win32_vc6\procinfo.lib</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Post-Build Event</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>attrib -r ..\..\utils\procinfo\lib\win32_vc6\procinfo.lib
+copy $(TargetPath) ..\..\utils\procinfo\lib\win32_vc6\procinfo.lib</Command>
+      <Message>Post-Build Event</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\procinfo\procinfo.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\procinfo\procinfo.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/procinfo.vcxproj.filters
+++ b/projects/vs2019/procinfo.vcxproj.filters
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{3d07af82-de85-47cb-bd87-125a9043c5ad}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\procinfo">
+      <UniqueIdentifier>{b8aff63a-415c-4e31-ad22-ba822090e8a2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{acb9edd8-ccf7-4221-8893-0cd5a3368fbc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\procinfo">
+      <UniqueIdentifier>{93d4c035-5f6d-4ffd-83c0-af849ad01f21}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\procinfo\procinfo.cpp">
+      <Filter>Source Files\utils\procinfo</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\procinfo\procinfo.h">
+      <Filter>Header Files\utils\procinfo</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/projects.sln
+++ b/projects/vs2019/projects.sln
@@ -1,0 +1,55 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30907.101
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "hldll", "hldll.vcxproj", "{69DDADC0-97F4-419E-86EB-C91781A0D2E0}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "hl_cdll", "hl_cdll.vcxproj", "{DC1DD765-CFEB-47DA-A2EA-9F1E20A24272}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dmcdll", "dmcdll.vcxproj", "{6C5EBEF4-40AE-4167-B3D5-26F0AB47E382}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dmc_cdll", "dmc_cdll.vcxproj", "{50BD4CD5-4043-4457-BA51-7CF8FFC43767}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ricochetdll", "ricochetdll.vcxproj", "{CE8DCBE4-D8DB-46E5-8607-8FCC5FA667FB}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ricochet_cdll", "ricochet_cdll.vcxproj", "{EA7DE935-F997-4EA8-9135-E2FE5E5D2C1B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{69DDADC0-97F4-419E-86EB-C91781A0D2E0}.Debug|Win32.ActiveCfg = Debug|Win32
+		{69DDADC0-97F4-419E-86EB-C91781A0D2E0}.Debug|Win32.Build.0 = Debug|Win32
+		{69DDADC0-97F4-419E-86EB-C91781A0D2E0}.Release|Win32.ActiveCfg = Release|Win32
+		{69DDADC0-97F4-419E-86EB-C91781A0D2E0}.Release|Win32.Build.0 = Release|Win32
+		{DC1DD765-CFEB-47DA-A2EA-9F1E20A24272}.Debug|Win32.ActiveCfg = Debug|Win32
+		{DC1DD765-CFEB-47DA-A2EA-9F1E20A24272}.Debug|Win32.Build.0 = Debug|Win32
+		{DC1DD765-CFEB-47DA-A2EA-9F1E20A24272}.Release|Win32.ActiveCfg = Release|Win32
+		{DC1DD765-CFEB-47DA-A2EA-9F1E20A24272}.Release|Win32.Build.0 = Release|Win32
+		{6C5EBEF4-40AE-4167-B3D5-26F0AB47E382}.Debug|Win32.ActiveCfg = Debug|Win32
+		{6C5EBEF4-40AE-4167-B3D5-26F0AB47E382}.Debug|Win32.Build.0 = Debug|Win32
+		{6C5EBEF4-40AE-4167-B3D5-26F0AB47E382}.Release|Win32.ActiveCfg = Release|Win32
+		{6C5EBEF4-40AE-4167-B3D5-26F0AB47E382}.Release|Win32.Build.0 = Release|Win32
+		{50BD4CD5-4043-4457-BA51-7CF8FFC43767}.Debug|Win32.ActiveCfg = Debug|Win32
+		{50BD4CD5-4043-4457-BA51-7CF8FFC43767}.Debug|Win32.Build.0 = Debug|Win32
+		{50BD4CD5-4043-4457-BA51-7CF8FFC43767}.Release|Win32.ActiveCfg = Release|Win32
+		{50BD4CD5-4043-4457-BA51-7CF8FFC43767}.Release|Win32.Build.0 = Release|Win32
+		{CE8DCBE4-D8DB-46E5-8607-8FCC5FA667FB}.Debug|Win32.ActiveCfg = Debug|Win32
+		{CE8DCBE4-D8DB-46E5-8607-8FCC5FA667FB}.Debug|Win32.Build.0 = Debug|Win32
+		{CE8DCBE4-D8DB-46E5-8607-8FCC5FA667FB}.Release|Win32.ActiveCfg = Release|Win32
+		{CE8DCBE4-D8DB-46E5-8607-8FCC5FA667FB}.Release|Win32.Build.0 = Release|Win32
+		{EA7DE935-F997-4EA8-9135-E2FE5E5D2C1B}.Debug|Win32.ActiveCfg = Debug|Win32
+		{EA7DE935-F997-4EA8-9135-E2FE5E5D2C1B}.Debug|Win32.Build.0 = Debug|Win32
+		{EA7DE935-F997-4EA8-9135-E2FE5E5D2C1B}.Release|Win32.ActiveCfg = Release|Win32
+		{EA7DE935-F997-4EA8-9135-E2FE5E5D2C1B}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CF04644F-4DDA-4852-A636-B7AC13826F23}
+	EndGlobalSection
+EndGlobal

--- a/projects/vs2019/qbsp2.vcxproj
+++ b/projects/vs2019/qbsp2.vcxproj
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\bsplib.h" />
+    <ClInclude Include="..\..\utils\common\cmdlib.h" />
+    <ClInclude Include="..\..\utils\common\mathlib.h" />
+    <ClInclude Include="..\..\utils\common\scriplib.h" />
+    <ClInclude Include="..\..\utils\common\threads.h" />
+    <ClInclude Include="..\..\utils\qbsp2\bsp5.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\bsplib.c" />
+    <ClCompile Include="..\..\utils\common\cmdlib.c" />
+    <ClCompile Include="..\..\utils\common\mathlib.c" />
+    <ClCompile Include="..\..\utils\common\scriplib.c" />
+    <ClCompile Include="..\..\utils\common\threads.c" />
+    <ClCompile Include="..\..\utils\qbsp2\gldraw.c" />
+    <ClCompile Include="..\..\utils\qbsp2\merge.c" />
+    <ClCompile Include="..\..\utils\qbsp2\outside.c" />
+    <ClCompile Include="..\..\utils\qbsp2\portals.c" />
+    <ClCompile Include="..\..\utils\qbsp2\qbsp.c" />
+    <ClCompile Include="..\..\utils\qbsp2\solidbsp.c" />
+    <ClCompile Include="..\..\utils\qbsp2\surfaces.c" />
+    <ClCompile Include="..\..\utils\qbsp2\tjunc.c" />
+    <ClCompile Include="..\..\utils\qbsp2\writebsp.c" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{415A5B85-BEA0-4F96-BBB6-5447E4CF726F}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>bspinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;DOUBLEVEC_T;_NOENUMQBOOL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common;..\..\external</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>opengl32.lib;glu32.lib;..\..\ext\glaux.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;DOUBLEVEC_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common;..\..\external</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>opengl32.lib;glu32.lib;..\..\ext\glaux.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/qbsp2.vcxproj.filters
+++ b/projects/vs2019/qbsp2.vcxproj.filters
@@ -1,0 +1,99 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{d5586ccb-fc7d-4e19-8bde-8656f3036ed7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{23430839-825c-42f8-87f8-5ae8dbcbb612}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\common">
+      <UniqueIdentifier>{b9529791-81ac-4e1b-86b7-e3ae05d40193}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\common">
+      <UniqueIdentifier>{9e2cd4d4-3990-41a2-ae01-1cdcaeb123b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\qbsp2">
+      <UniqueIdentifier>{d644c063-b652-4ccb-8bcb-f55aad917c62}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\qbsp2">
+      <UniqueIdentifier>{b5377a13-8c89-4fca-9dc1-d94312a449cd}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\qbsp2\bsp5.h">
+      <Filter>Header Files\utils\qbsp2</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\bsplib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\threads.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\cmdlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\mathlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\scriplib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\bsplib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\cmdlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\mathlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qbsp2\gldraw.c">
+      <Filter>Source Files\utils\qbsp2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qbsp2\portals.c">
+      <Filter>Source Files\utils\qbsp2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qbsp2\merge.c">
+      <Filter>Source Files\utils\qbsp2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qbsp2\outside.c">
+      <Filter>Source Files\utils\qbsp2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qbsp2\qbsp.c">
+      <Filter>Source Files\utils\qbsp2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qbsp2\surfaces.c">
+      <Filter>Source Files\utils\qbsp2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qbsp2\solidbsp.c">
+      <Filter>Source Files\utils\qbsp2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\threads.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\scriplib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qbsp2\writebsp.c">
+      <Filter>Source Files\utils\qbsp2</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qbsp2\tjunc.c">
+      <Filter>Source Files\utils\qbsp2</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/qcsg.vcxproj
+++ b/projects/vs2019/qcsg.vcxproj
@@ -1,0 +1,112 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\bspfile.c" />
+    <ClCompile Include="..\..\utils\common\cmdlib.c" />
+    <ClCompile Include="..\..\utils\common\mathlib.c" />
+    <ClCompile Include="..\..\utils\common\polylib.c" />
+    <ClCompile Include="..\..\utils\common\scriplib.c" />
+    <ClCompile Include="..\..\utils\common\threads.c" />
+    <ClCompile Include="..\..\utils\qcsg\brush.c" />
+    <ClCompile Include="..\..\utils\qcsg\gldraw.c" />
+    <ClCompile Include="..\..\utils\qcsg\hullfile.c" />
+    <ClCompile Include="..\..\utils\qcsg\map.c" />
+    <ClCompile Include="..\..\utils\qcsg\qcsg.c" />
+    <ClCompile Include="..\..\utils\qcsg\textures.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\bspfile.h" />
+    <ClInclude Include="..\..\utils\common\cmdlib.h" />
+    <ClInclude Include="..\..\utils\common\mathlib.h" />
+    <ClInclude Include="..\..\utils\common\polylib.h" />
+    <ClInclude Include="..\..\utils\common\scriplib.h" />
+    <ClInclude Include="..\..\utils\common\threads.h" />
+    <ClInclude Include="..\..\utils\qcsg\csg.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{0F44E796-FAFD-4D52-91DE-707B5FB27841}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>bspinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;DOUBLEVEC_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common;../../external</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>opengl32.lib;glu32.lib;..\..\ext\glaux.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;DOUBLEVEC_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common;../../external</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>opengl32.lib;glu32.lib;..\..\ext\glaux.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/qcsg.vcxproj.filters
+++ b/projects/vs2019/qcsg.vcxproj.filters
@@ -1,0 +1,96 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{d5586ccb-fc7d-4e19-8bde-8656f3036ed7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{23430839-825c-42f8-87f8-5ae8dbcbb612}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\common">
+      <UniqueIdentifier>{b9529791-81ac-4e1b-86b7-e3ae05d40193}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\common">
+      <UniqueIdentifier>{9e2cd4d4-3990-41a2-ae01-1cdcaeb123b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\qcsg">
+      <UniqueIdentifier>{c207af92-a0f3-402b-b5c1-7ae72a1d972c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\qcsg">
+      <UniqueIdentifier>{a4552d55-15d2-4b83-850f-cef12647285f}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\qcsg\brush.c">
+      <Filter>Source Files\utils\qcsg</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\bspfile.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\polylib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\cmdlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\mathlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qcsg\qcsg.c">
+      <Filter>Source Files\utils\qcsg</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qcsg\gldraw.c">
+      <Filter>Source Files\utils\qcsg</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qcsg\hullfile.c">
+      <Filter>Source Files\utils\qcsg</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qcsg\map.c">
+      <Filter>Source Files\utils\qcsg</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qcsg\textures.c">
+      <Filter>Source Files\utils\qcsg</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\scriplib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\threads.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\threads.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\bspfile.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\cmdlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\mathlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\polylib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\scriplib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\qcsg\csg.h">
+      <Filter>Header Files\utils\qcsg</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/qlumpy.vcxproj
+++ b/projects/vs2019/qlumpy.vcxproj
@@ -1,0 +1,102 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\cmdlib.c" />
+    <ClCompile Include="..\..\utils\common\lbmlib.c" />
+    <ClCompile Include="..\..\utils\common\scriplib.c" />
+    <ClCompile Include="..\..\utils\common\wadlib.c" />
+    <ClCompile Include="..\..\utils\qlumpy\qlumpy.c" />
+    <ClCompile Include="..\..\utils\qlumpy\quakegrb.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\cmdlib.h" />
+    <ClInclude Include="..\..\utils\common\lbmlib.h" />
+    <ClInclude Include="..\..\utils\common\scriplib.h" />
+    <ClInclude Include="..\..\utils\common\wadlib.h" />
+    <ClInclude Include="..\..\utils\qlumpy\qlumpy.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{01780C5F-55A2-41D4-B27F-6383BB549DE4}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>bspinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/qlumpy.vcxproj.filters
+++ b/projects/vs2019/qlumpy.vcxproj.filters
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{d5586ccb-fc7d-4e19-8bde-8656f3036ed7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{23430839-825c-42f8-87f8-5ae8dbcbb612}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\common">
+      <UniqueIdentifier>{b9529791-81ac-4e1b-86b7-e3ae05d40193}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\common">
+      <UniqueIdentifier>{9e2cd4d4-3990-41a2-ae01-1cdcaeb123b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\qlumpy">
+      <UniqueIdentifier>{40830782-1c0d-42a8-85f0-09f7e3f4ff75}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\qlumpy">
+      <UniqueIdentifier>{b2425109-9ba3-4a19-9a54-7451f3a87a23}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\wadlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\cmdlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\lbmlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\scriplib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qlumpy\quakegrb.c">
+      <Filter>Source Files\utils\qlumpy</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qlumpy\qlumpy.c">
+      <Filter>Source Files\utils\qlumpy</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\qlumpy\qlumpy.h">
+      <Filter>Header Files\utils\qlumpy</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\wadlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\cmdlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\lbmlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\scriplib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/qrad.vcxproj
+++ b/projects/vs2019/qrad.vcxproj
@@ -1,0 +1,108 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\bspfile.c" />
+    <ClCompile Include="..\..\utils\common\cmdlib.c" />
+    <ClCompile Include="..\..\utils\common\mathlib.c" />
+    <ClCompile Include="..\..\utils\common\polylib.c" />
+    <ClCompile Include="..\..\utils\common\scriplib.c" />
+    <ClCompile Include="..\..\utils\common\threads.c" />
+    <ClCompile Include="..\..\utils\qrad\lightmap.c" />
+    <ClCompile Include="..\..\utils\qrad\qrad.c" />
+    <ClCompile Include="..\..\utils\qrad\trace.c" />
+    <ClCompile Include="..\..\utils\qrad\vismat.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\bspfile.h" />
+    <ClInclude Include="..\..\utils\common\cmdlib.h" />
+    <ClInclude Include="..\..\utils\common\mathlib.h" />
+    <ClInclude Include="..\..\utils\common\polylib.h" />
+    <ClInclude Include="..\..\utils\common\scriplib.h" />
+    <ClInclude Include="..\..\utils\common\threads.h" />
+    <ClInclude Include="..\..\utils\qrad\qrad.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A015F691-DF6B-4E05-AB3B-4B0A55C13EDC}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>bspinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/qrad.vcxproj.filters
+++ b/projects/vs2019/qrad.vcxproj.filters
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{d5586ccb-fc7d-4e19-8bde-8656f3036ed7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{23430839-825c-42f8-87f8-5ae8dbcbb612}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\common">
+      <UniqueIdentifier>{b9529791-81ac-4e1b-86b7-e3ae05d40193}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\common">
+      <UniqueIdentifier>{9e2cd4d4-3990-41a2-ae01-1cdcaeb123b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\qrad">
+      <UniqueIdentifier>{bcc621aa-c3f2-45d3-8c92-d4c1dab462b4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\qrad">
+      <UniqueIdentifier>{67707ba9-3f42-423a-9494-4cbdce9f8710}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\bspfile.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\cmdlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\mathlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\polylib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\scriplib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\threads.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qrad\vismat.c">
+      <Filter>Source Files\utils\qrad</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qrad\lightmap.c">
+      <Filter>Source Files\utils\qrad</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qrad\qrad.c">
+      <Filter>Source Files\utils\qrad</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\qrad\trace.c">
+      <Filter>Source Files\utils\qrad</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\threads.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\bspfile.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\cmdlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\mathlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\polylib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\scriplib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\qrad\qrad.h">
+      <Filter>Header Files\utils\qrad</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/ricochet_cdll.vcxproj
+++ b/projects/vs2019/ricochet_cdll.vcxproj
@@ -1,0 +1,206 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\common\parsemsg.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_checkbutton2.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_grid.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_helpers.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_listbox.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_loadtga.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_scrollbar2.cpp" />
+    <ClCompile Include="..\..\game_shared\vgui_slider2.cpp" />
+    <ClCompile Include="..\..\game_shared\voice_banmgr.cpp" />
+    <ClCompile Include="..\..\public\interface.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\ammo.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\ammohistory.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\ammo_secondary.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\battery.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\cdll_int.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\com_weapons.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\death.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\demo.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\entity.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\events.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\ev_common.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\ev_hldm.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\flashlight.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\GameStudioModelRenderer.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\geiger.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\health.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\hl\hl_baseentity.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\hl\hl_events.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\hl\hl_objects.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\hl\hl_weapons.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\hud.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\hud_msg.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\hud_redraw.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\hud_servers.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\hud_update.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\input.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\inputw32.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\in_camera.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\menu.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\message.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\Ricochet_JumpPads.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\saytext.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\statusbar.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\status_icons.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\StudioModelRenderer.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\studio_util.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\text_message.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\train.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\tri.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\util.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_ConsolePanel.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_ControlConfigPanel.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_CustomObjects.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_discobjects.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_int.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_MOTDWindow.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_SchemeManager.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_ScorePanel.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_ServerBrowser.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_TeamFortressViewport.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\view.cpp" />
+    <ClCompile Include="..\..\ricochet\cl_dll\voice_status.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\wpn_shared\disc_weapon_disc.cpp" />
+    <ClCompile Include="..\..\ricochet\pm_shared\pm_debug.c" />
+    <ClCompile Include="..\..\ricochet\pm_shared\pm_math.c" />
+    <ClCompile Include="..\..\ricochet\pm_shared\pm_shared.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\common\parsemsg.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\ammo.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\ammohistory.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\camera.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\cl_dll.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\cl_util.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\com_weapons.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\demo.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\eventscripts.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\ev_hldm.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\GameStudioModelRenderer.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\health.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\hud.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\hud_iface.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\hud_servers.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\hud_servers_priv.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\in_defs.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\kbutton.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\Ricochet_BSPFile.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\Ricochet_JumpPads.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\StudioModelRenderer.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\studio_util.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\util_vector.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_ConsolePanel.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_ControlConfigPanel.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_discobjects.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_int.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_SchemeManager.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_ScorePanel.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_ServerBrowser.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_TeamFortressViewport.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\view.h" />
+    <ClInclude Include="..\..\ricochet\cl_dll\wrect.h" />
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_debug.h" />
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_defs.h" />
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_info.h" />
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_materials.h" />
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_movevars.h" />
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_shared.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{EA7DE935-F997-4EA8-9135-E2FE5E5D2C1B}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ricochet_cdll</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <TargetName>client</TargetName>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <TargetName>client</TargetName>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;CLIENT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\..\ricochet;..\..\ricochet\dlls;..\..\ricochet\cl_dll;..\..\game_shared;..\..\engine;..\..\public;..\..\common;..\..\ricochet\pm_shared;..\..\utils\vgui\include;..\..\external;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>..\..\utils\vgui\lib\win32_vc6\vgui.lib;wsock32.lib;..\..\lib\public\sdl2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <BaseAddress>
+      </BaseAddress>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;CLIENT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\..\ricochet;..\..\ricochet\dlls;..\..\ricochet\cl_dll;..\..\game_shared;..\..\engine;..\..\public;..\..\common;..\..\ricochet\pm_shared;..\..\utils\vgui\include;..\..\external;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>..\..\utils\vgui\lib\win32_vc6\vgui.lib;wsock32.lib;..\..\lib\public\sdl2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <BaseAddress>
+      </BaseAddress>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/ricochet_cdll.vcxproj.filters
+++ b/projects/vs2019/ricochet_cdll.vcxproj.filters
@@ -1,0 +1,384 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\_hl">
+      <UniqueIdentifier>{0142d5e4-5caa-4286-8740-78fe5f63f90c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_hl\ricochet">
+      <UniqueIdentifier>{d79b1e48-d35a-4c47-a48a-06c124d7d5f2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_hl\ricochet\dlls">
+      <UniqueIdentifier>{db1142bc-09dd-40f1-8e5b-7d2e5873fbfb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_hl\ricochet\dlls\wpn_shared">
+      <UniqueIdentifier>{14ceca51-597d-4ae0-ad1e-616f9c76afb7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_hl\ricochet\cl_dll">
+      <UniqueIdentifier>{a659561b-3095-458c-9ac3-98a1f8fda89d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\_hl\ricochet\cl_dll\hl">
+      <UniqueIdentifier>{de1d2011-0a49-4c1e-b1ee-e6e31c6ba173}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\ricochet">
+      <UniqueIdentifier>{8f0ebcb6-1036-4fb2-8955-0992878a0f76}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\ricochet\cl_dll">
+      <UniqueIdentifier>{6d32d06c-ab53-4cc4-9580-61fd0802aeb7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\public">
+      <UniqueIdentifier>{a62dbc7a-0e7a-4926-9415-c81e6b3e2820}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\common">
+      <UniqueIdentifier>{2263acfb-32b9-437e-b357-289dc027689c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\ricochet\pm_shared">
+      <UniqueIdentifier>{739d96f5-318f-4326-ac16-acad51f23a39}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\game_shared">
+      <UniqueIdentifier>{0f1d61fd-fd1b-41fb-aa84-b3226848ae8c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\ricochet">
+      <UniqueIdentifier>{482b21b8-5e14-4d3a-9f6d-000f8fe9c81d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\ricochet\cl_dll">
+      <UniqueIdentifier>{8ee6bc62-6027-4bb6-bba1-bd7eb71b8ded}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\common">
+      <UniqueIdentifier>{acab3107-5b1a-47d3-95fa-d374360ea28c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\ricochet\pm_shared">
+      <UniqueIdentifier>{2c1b936b-1f82-449f-be5a-1254ef73c3d2}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\ricochet\dlls\wpn_shared\disc_weapon_disc.cpp">
+      <Filter>Source Files\_hl\ricochet\dlls\wpn_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\ev_hldm.cpp">
+      <Filter>Source Files\_hl\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\hl\hl_baseentity.cpp">
+      <Filter>Source Files\_hl\ricochet\cl_dll\hl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\hl\hl_events.cpp">
+      <Filter>Source Files\_hl\ricochet\cl_dll\hl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\hl\hl_objects.cpp">
+      <Filter>Source Files\_hl\ricochet\cl_dll\hl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\hl\hl_weapons.cpp">
+      <Filter>Source Files\_hl\ricochet\cl_dll\hl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\Ricochet_JumpPads.cpp">
+      <Filter>Source Files\_hl\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\input.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\inputw32.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\ammo.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\ammo_secondary.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\ammohistory.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\battery.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\cdll_int.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\com_weapons.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\death.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\demo.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\entity.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\ev_common.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\events.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\flashlight.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\GameStudioModelRenderer.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\geiger.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\health.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\hud.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\hud_msg.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\hud_redraw.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\hud_servers.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\hud_update.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\in_camera.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\public\interface.cpp">
+      <Filter>Source Files\public</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\common\parsemsg.cpp">
+      <Filter>Source Files\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\pm_shared\pm_shared.c">
+      <Filter>Source Files\ricochet\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\pm_shared\pm_debug.c">
+      <Filter>Source Files\ricochet\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\pm_shared\pm_math.c">
+      <Filter>Source Files\ricochet\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\saytext.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\menu.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\message.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\tri.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\util.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\status_icons.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\statusbar.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\studio_util.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\StudioModelRenderer.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\text_message.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\train.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_helpers.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_checkbutton2.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_grid.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_int.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_ConsolePanel.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_ControlConfigPanel.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_CustomObjects.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_discobjects.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_scrollbar2.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_listbox.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_loadtga.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\vgui_slider2.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_MOTDWindow.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_SchemeManager.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_ScorePanel.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_ServerBrowser.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\vgui_TeamFortressViewport.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\voice_banmgr.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\voice_status.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\cl_dll\view.cpp">
+      <Filter>Source Files\ricochet\cl_dll</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\ricochet\cl_dll\kbutton.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\ammo.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\ammohistory.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\camera.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\cl_dll.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\cl_util.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\com_weapons.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\demo.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\ev_hldm.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\eventscripts.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\GameStudioModelRenderer.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\health.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\hud.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\hud_iface.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\hud_servers.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\hud_servers_priv.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\in_defs.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\common\parsemsg.h">
+      <Filter>Header Files\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_shared.h">
+      <Filter>Header Files\ricochet\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_debug.h">
+      <Filter>Header Files\ricochet\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_defs.h">
+      <Filter>Header Files\ricochet\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_info.h">
+      <Filter>Header Files\ricochet\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_materials.h">
+      <Filter>Header Files\ricochet\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_movevars.h">
+      <Filter>Header Files\ricochet\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\wrect.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\Ricochet_BSPFile.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\Ricochet_JumpPads.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\studio_util.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\StudioModelRenderer.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\util_vector.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_ConsolePanel.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_ControlConfigPanel.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_discobjects.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_int.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_SchemeManager.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_ScorePanel.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_ServerBrowser.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\vgui_TeamFortressViewport.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\cl_dll\view.h">
+      <Filter>Header Files\ricochet\cl_dll</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/ricochetdll.vcxproj
+++ b/projects/vs2019/ricochetdll.vcxproj
@@ -1,0 +1,193 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\game_shared\voice_gamemgr.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\airtank.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\animating.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\animation.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\bmodels.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\buttons.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\cbase.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\client.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\combat.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\disc_arena.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\disc_powerups.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\doors.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\effects.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\explode.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\func_break.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\func_tank.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\game.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\gamerules.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\ggrenade.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\globals.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\healthkit.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\h_ai.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\h_battery.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\h_cycler.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\h_export.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\items.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\lights.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\maprules.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\mortar.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\mpstubb.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\multiplay_gamerules.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\observer.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\pathcorner.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\plane.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\plats.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\player.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\singleplay_gamerules.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\skill.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\sound.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\soundent.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\spectator.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\subs.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\teamplay_gamerules.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\triggers.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\util.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\weapons.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\world.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\wpn_shared\disc_weapon_disc.cpp" />
+    <ClCompile Include="..\..\ricochet\dlls\xen.cpp" />
+    <ClCompile Include="..\..\ricochet\pm_shared\pm_debug.c" />
+    <ClCompile Include="..\..\ricochet\pm_shared\pm_math.c" />
+    <ClCompile Include="..\..\ricochet\pm_shared\pm_shared.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\ricochet\dlls\activity.h" />
+    <ClInclude Include="..\..\ricochet\dlls\activitymap.h" />
+    <ClInclude Include="..\..\ricochet\dlls\animation.h" />
+    <ClInclude Include="..\..\ricochet\dlls\basemonster.h" />
+    <ClInclude Include="..\..\ricochet\dlls\cbase.h" />
+    <ClInclude Include="..\..\ricochet\dlls\cdll_dll.h" />
+    <ClInclude Include="..\..\ricochet\dlls\client.h" />
+    <ClInclude Include="..\..\ricochet\dlls\decals.h" />
+    <ClInclude Include="..\..\ricochet\dlls\discwar.h" />
+    <ClInclude Include="..\..\ricochet\dlls\disc_arena.h" />
+    <ClInclude Include="..\..\ricochet\dlls\doors.h" />
+    <ClInclude Include="..\..\ricochet\dlls\effects.h" />
+    <ClInclude Include="..\..\ricochet\dlls\enginecallback.h" />
+    <ClInclude Include="..\..\ricochet\dlls\explode.h" />
+    <ClInclude Include="..\..\ricochet\dlls\extdll.h" />
+    <ClInclude Include="..\..\ricochet\dlls\func_break.h" />
+    <ClInclude Include="..\..\ricochet\dlls\game.h" />
+    <ClInclude Include="..\..\ricochet\dlls\gamerules.h" />
+    <ClInclude Include="..\..\ricochet\dlls\hornet.h" />
+    <ClInclude Include="..\..\ricochet\dlls\items.h" />
+    <ClInclude Include="..\..\ricochet\dlls\maprules.h" />
+    <ClInclude Include="..\..\ricochet\dlls\monsterevent.h" />
+    <ClInclude Include="..\..\ricochet\dlls\monsters.h" />
+    <ClInclude Include="..\..\ricochet\dlls\nodes.h" />
+    <ClInclude Include="..\..\ricochet\dlls\plane.h" />
+    <ClInclude Include="..\..\ricochet\dlls\player.h" />
+    <ClInclude Include="..\..\ricochet\dlls\saverestore.h" />
+    <ClInclude Include="..\..\ricochet\dlls\schedule.h" />
+    <ClInclude Include="..\..\ricochet\dlls\scriptevent.h" />
+    <ClInclude Include="..\..\ricochet\dlls\skill.h" />
+    <ClInclude Include="..\..\ricochet\dlls\soundent.h" />
+    <ClInclude Include="..\..\ricochet\dlls\spectator.h" />
+    <ClInclude Include="..\..\ricochet\dlls\talkmonster.h" />
+    <ClInclude Include="..\..\ricochet\dlls\teamplay_gamerules.h" />
+    <ClInclude Include="..\..\ricochet\dlls\trains.h" />
+    <ClInclude Include="..\..\ricochet\dlls\util.h" />
+    <ClInclude Include="..\..\ricochet\dlls\vector.h" />
+    <ClInclude Include="..\..\ricochet\dlls\weapons.h" />
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_debug.h" />
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_defs.h" />
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_info.h" />
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_materials.h" />
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_movevars.h" />
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_shared.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{CE8DCBE4-D8DB-46E5-8607-8FCC5FA667FB}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ricochetdll</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+    <TargetName>mp</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+    <TargetName>mp</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;VALVE_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\ricochet\dlls;..\..\engine;..\..\common;..\..\public;..\..\game_shared;..\..\ricochet\pm_shared;..\..\ricochet;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>$(ProjectDir)..\..\ricochet\dlls\mp.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;VALVE_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\ricochet\dlls;..\..\engine;..\..\common;..\..\public;..\..\game_shared;..\..\ricochet\pm_shared;..\..\ricochet;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <ModuleDefinitionFile>$(ProjectDir)..\..\ricochet\dlls\mp.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/ricochetdll.vcxproj.filters
+++ b/projects/vs2019/ricochetdll.vcxproj.filters
@@ -1,0 +1,333 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\ricochet">
+      <UniqueIdentifier>{a3e19434-b8d9-43ec-a1ed-e260f8aee591}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\ricochet\dlls">
+      <UniqueIdentifier>{9b833c3f-4e64-4ba6-9143-c7a365cef6fa}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\ricochet\dlls\wpn_shared">
+      <UniqueIdentifier>{c683dfc8-f9d2-49d0-bc80-c2aa7e10dab5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\ricochet\pm_shared">
+      <UniqueIdentifier>{6334b1f8-a9a7-44e0-a020-afa31543406a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\game_shared">
+      <UniqueIdentifier>{be7399a9-5600-4d83-b06d-4edbed45200b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\ricochet">
+      <UniqueIdentifier>{684ab4d1-82f9-4ff3-868a-0d9919cc32f7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\ricochet\dlls">
+      <UniqueIdentifier>{2dc019ff-0dfb-4478-9ecd-58c90ae0111e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\ricochet\pm_shared">
+      <UniqueIdentifier>{8b020c05-4536-4f4f-82c9-2206caef635a}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\ricochet\dlls\disc_powerups.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\airtank.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\animating.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\animation.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\bmodels.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\buttons.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\cbase.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\client.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\combat.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\disc_arena.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\wpn_shared\disc_weapon_disc.cpp">
+      <Filter>Source Files\ricochet\dlls\wpn_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\player.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\doors.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\effects.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\explode.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\func_break.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\func_tank.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\game.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\gamerules.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\ggrenade.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\globals.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\h_ai.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\h_battery.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\h_cycler.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\h_export.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\healthkit.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\items.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\lights.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\maprules.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\mortar.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\mpstubb.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\multiplay_gamerules.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\observer.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\pathcorner.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\plane.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\plats.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\pm_shared\pm_shared.c">
+      <Filter>Source Files\ricochet\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\pm_shared\pm_debug.c">
+      <Filter>Source Files\ricochet\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\pm_shared\pm_math.c">
+      <Filter>Source Files\ricochet\pm_shared</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\world.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\xen.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\singleplay_gamerules.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\skill.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\sound.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\soundent.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\spectator.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\subs.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\teamplay_gamerules.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\triggers.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\util.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ricochet\dlls\weapons.cpp">
+      <Filter>Source Files\ricochet\dlls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\game_shared\voice_gamemgr.cpp">
+      <Filter>Source Files\game_shared</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\ricochet\dlls\gamerules.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\activity.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\activitymap.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\animation.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\basemonster.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\cbase.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\cdll_dll.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\client.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\decals.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\disc_arena.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\discwar.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\doors.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\effects.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\enginecallback.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\explode.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\extdll.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\func_break.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\game.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\player.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\hornet.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\items.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\maprules.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\monsterevent.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\monsters.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\nodes.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\plane.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_shared.h">
+      <Filter>Header Files\ricochet\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_debug.h">
+      <Filter>Header Files\ricochet\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_defs.h">
+      <Filter>Header Files\ricochet\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_info.h">
+      <Filter>Header Files\ricochet\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_materials.h">
+      <Filter>Header Files\ricochet\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\pm_shared\pm_movevars.h">
+      <Filter>Header Files\ricochet\pm_shared</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\weapons.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\saverestore.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\schedule.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\scriptevent.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\skill.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\soundent.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\spectator.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\talkmonster.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\teamplay_gamerules.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\trains.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\util.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ricochet\dlls\vector.h">
+      <Filter>Header Files\ricochet\dlls</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/serverctrl.vcxproj
+++ b/projects/vs2019/serverctrl.vcxproj
@@ -1,0 +1,114 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{AF96A753-E234-4692-90AB-CCD802E34E9C}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>serverctrl</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <UseOfMfc>Dynamic</UseOfMfc>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <UseOfMfc>Dynamic</UseOfMfc>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>E:\WinDDK\7600.16385.1\inc\atl71;E:\WinDDK\7600.16385.1\inc\mfc42;$(IncludePath)</IncludePath>
+    <LibraryPath>E:\WinDDK\7600.16385.1\lib\ATL\i386;E:\WinDDK\7600.16385.1\lib\Mfc\i386;$(LibraryPath)</LibraryPath>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>E:\WinDDK\7600.16385.1\inc\atl71;E:\WinDDK\7600.16385.1\inc\mfc42;$(IncludePath)</IncludePath>
+    <LibraryPath>E:\WinDDK\7600.16385.1\lib\ATL\i386;E:\WinDDK\7600.16385.1\lib\Mfc\i386;$(LibraryPath)</LibraryPath>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\serverctrl\ServerCtrl.cpp" />
+    <ClCompile Include="..\..\utils\serverctrl\ServerCtrlDlg.cpp" />
+    <ClCompile Include="..\..\utils\serverctrl\StdAfx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\utils\serverctrl\ServerCtrl.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\serverctrl\resource.h" />
+    <ClInclude Include="..\..\utils\serverctrl\ServerCtrl.h" />
+    <ClInclude Include="..\..\utils\serverctrl\ServerCtrlDlg.h" />
+    <ClInclude Include="..\..\utils\serverctrl\StdAfx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\utils\serverctrl\res\serverctrl.ico" />
+    <None Include="..\..\utils\serverctrl\res\serverctrl.rc2" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/serverctrl.vcxproj.filters
+++ b/projects/vs2019/serverctrl.vcxproj.filters
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{b6851a08-110d-4b63-97bb-002b6c26576e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\serverctrl">
+      <UniqueIdentifier>{b210c226-0069-49ec-87ea-a3c9c16d737b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{7ffbb312-a0a2-4787-af0a-d3e499f4c628}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\servertrl">
+      <UniqueIdentifier>{5de03485-5c29-4f54-95df-161e73d864e2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Resource Files\utils">
+      <UniqueIdentifier>{1b20963c-0f73-4f11-a8ff-8cec4041bf4c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Resource Files\utils\serverctrl">
+      <UniqueIdentifier>{f55832d2-48da-4c3e-90bd-66f24f495211}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Resource Files\utils\serverctrl\res">
+      <UniqueIdentifier>{d2b2c612-d341-4167-80d5-a49ae6887f4a}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\serverctrl\ServerCtrl.cpp">
+      <Filter>Source Files\utils\servertrl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\serverctrl\StdAfx.cpp">
+      <Filter>Source Files\utils\servertrl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\serverctrl\ServerCtrlDlg.cpp">
+      <Filter>Source Files\utils\servertrl</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\serverctrl\resource.h">
+      <Filter>Header Files\utils\serverctrl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\serverctrl\ServerCtrlDlg.h">
+      <Filter>Header Files\utils\serverctrl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\serverctrl\ServerCtrl.h">
+      <Filter>Header Files\utils\serverctrl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\serverctrl\StdAfx.h">
+      <Filter>Header Files\utils\serverctrl</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\utils\serverctrl\ServerCtrl.rc">
+      <Filter>Source Files\utils\servertrl</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\utils\serverctrl\res\serverctrl.ico">
+      <Filter>Resource Files\utils\serverctrl\res</Filter>
+    </None>
+    <None Include="..\..\utils\serverctrl\res\serverctrl.rc2">
+      <Filter>Resource Files\utils\serverctrl\res</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/smdlexp.vcxproj
+++ b/projects/vs2019/smdlexp.vcxproj
@@ -1,0 +1,121 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{4BFEAD42-DBED-40F0-B30E-E5AF9EBA59A8}</ProjectGuid>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <Keyword>ManagedCProj</Keyword>
+    <RootNamespace>procinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>c:\3dsmax42\maxsdk\include;c:\3dsmax42\cstudio\sdk;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>COMCTL32.LIB;maxutil.lib;geom.lib;mesh.lib;core.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>c:\3dsmax42\maxsdk\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <OutputFile>c:\3dsmax42\plugins\smdlexp.dle</OutputFile>
+      <ModuleDefinitionFile>$(ProjectDir)..\..\utils\smdlexp\smdlexp.def</ModuleDefinitionFile>
+    </Link>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Post-Build Event</Message>
+    </PostBuildEvent>
+    <Lib>
+      <AdditionalDependencies>COMCTL32.LIB;maxutil.lib;geom.lib;mesh.lib;core.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>c:\3dsmax42\maxsdk\include;c:\3dsmax42\cstudio\sdk;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>COMCTL32.LIB;maxutil.lib;geom.lib;mesh.lib;core.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>c:\3dsmax42\maxsdk\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <OutputFile>c:\3dsmax42\plugins\smdlexp.dle</OutputFile>
+      <ModuleDefinitionFile>$(ProjectDir)..\..\utils\smdlexp\smdlexp.def</ModuleDefinitionFile>
+    </Link>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+      <Message>Post-Build Event</Message>
+    </PostBuildEvent>
+    <Lib>
+      <AdditionalDependencies>COMCTL32.LIB;maxutil.lib;geom.lib;mesh.lib;core.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\utils\smdlexp\smdlexp.def" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\utils\smdlexp\smdlexp.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\smdlexp\smdlexp.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\smdlexp\smedefs.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/smdlexp.vcxproj.filters
+++ b/projects/vs2019/smdlexp.vcxproj.filters
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{3d07af82-de85-47cb-bd87-125a9043c5ad}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{acb9edd8-ccf7-4221-8893-0cd5a3368fbc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\smdlexp">
+      <UniqueIdentifier>{c35dd471-5706-455f-bd22-6964d0906c6e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Resource Files\utils">
+      <UniqueIdentifier>{17940ef9-04e1-45c8-b52e-7030fbd6de03}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Resource Files\utils\smdlexp">
+      <UniqueIdentifier>{3980e5e7-942c-40ad-9660-0a40a185ede0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\smdlexp">
+      <UniqueIdentifier>{d82ea4d8-83a8-4071-b2c6-379a38d00c5b}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\..\utils\smdlexp\smdlexp.rc">
+      <Filter>Resource Files\utils\smdlexp</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\smdlexp\smdlexp.cpp">
+      <Filter>Source Files\utils\smdlexp</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\utils\smdlexp\smdlexp.def">
+      <Filter>Source Files\utils\smdlexp</Filter>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\smdlexp\smedefs.h">
+      <Filter>Header Files\utils\smdlexp</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/sprgen.vcxproj
+++ b/projects/vs2019/sprgen.vcxproj
@@ -1,0 +1,99 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\cmdlib.c" />
+    <ClCompile Include="..\..\utils\common\lbmlib.c" />
+    <ClCompile Include="..\..\utils\common\scriplib.c" />
+    <ClCompile Include="..\..\utils\sprgen\sprgen.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\cmdlib.h" />
+    <ClInclude Include="..\..\utils\common\lbmlib.h" />
+    <ClInclude Include="..\..\utils\common\scriplib.h" />
+    <ClInclude Include="..\..\utils\sprgen\spritegn.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{2ADCE88F-5117-4D09-BE30-C8CBE902203E}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>bspinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/sprgen.vcxproj.filters
+++ b/projects/vs2019/sprgen.vcxproj.filters
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{d5586ccb-fc7d-4e19-8bde-8656f3036ed7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{23430839-825c-42f8-87f8-5ae8dbcbb612}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\common">
+      <UniqueIdentifier>{b9529791-81ac-4e1b-86b7-e3ae05d40193}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\common">
+      <UniqueIdentifier>{9e2cd4d4-3990-41a2-ae01-1cdcaeb123b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\sprgen">
+      <UniqueIdentifier>{b4223f35-828f-4e8c-a089-ba9f4ca7e0ac}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\sprgen">
+      <UniqueIdentifier>{a02f46e8-81c1-476c-a7f2-b222251f96e7}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\scriplib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\cmdlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\lbmlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\sprgen\sprgen.c">
+      <Filter>Source Files\utils\sprgen</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\scriplib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\cmdlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\lbmlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\sprgen\spritegn.h">
+      <Filter>Header Files\utils\sprgen</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/studiomdl.vcxproj
+++ b/projects/vs2019/studiomdl.vcxproj
@@ -1,0 +1,106 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\cmdlib.c" />
+    <ClCompile Include="..\..\utils\common\lbmlib.c" />
+    <ClCompile Include="..\..\utils\common\mathlib.c" />
+    <ClCompile Include="..\..\utils\common\scriplib.c" />
+    <ClCompile Include="..\..\utils\common\trilib.c" />
+    <ClCompile Include="..\..\utils\studiomdl\bmpread.c" />
+    <ClCompile Include="..\..\utils\studiomdl\studiomdl.c" />
+    <ClCompile Include="..\..\utils\studiomdl\tristrip.c" />
+    <ClCompile Include="..\..\utils\studiomdl\write.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\cmdlib.h" />
+    <ClInclude Include="..\..\utils\common\lbmlib.h" />
+    <ClInclude Include="..\..\utils\common\mathlib.h" />
+    <ClInclude Include="..\..\utils\common\scriplib.h" />
+    <ClInclude Include="..\..\utils\common\trilib.h" />
+    <ClInclude Include="..\..\utils\studiomdl\studiomdl.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{5A257608-0B80-42ED-A037-C2A02E878301}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>bspinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common;../../common;../../public</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common;../../common;../../public</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/studiomdl.vcxproj.filters
+++ b/projects/vs2019/studiomdl.vcxproj.filters
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{d5586ccb-fc7d-4e19-8bde-8656f3036ed7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{23430839-825c-42f8-87f8-5ae8dbcbb612}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\common">
+      <UniqueIdentifier>{b9529791-81ac-4e1b-86b7-e3ae05d40193}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\common">
+      <UniqueIdentifier>{9e2cd4d4-3990-41a2-ae01-1cdcaeb123b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\studiomdl">
+      <UniqueIdentifier>{11d3635c-ec17-499c-aed9-8ccc565db4ce}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\studiomdl">
+      <UniqueIdentifier>{d8c1382c-f41c-4569-a63d-a9bb68fb7a8a}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\trilib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\cmdlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\lbmlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\mathlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\scriplib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\studiomdl\write.c">
+      <Filter>Source Files\utils\studiomdl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\studiomdl\bmpread.c">
+      <Filter>Source Files\utils\studiomdl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\studiomdl\studiomdl.c">
+      <Filter>Source Files\utils\studiomdl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\studiomdl\tristrip.c">
+      <Filter>Source Files\utils\studiomdl</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\trilib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\cmdlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\lbmlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\mathlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\scriplib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\studiomdl\studiomdl.h">
+      <Filter>Header Files\utils\studiomdl</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/utils.sln
+++ b/projects/vs2019/utils.sln
@@ -1,0 +1,115 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30907.101
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bspinfo", "bspinfo.vcxproj", "{B1227C36-C02C-4914-9675-C6D243D8B36E}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "light", "light.vcxproj", "{1D9A402B-C7AB-4DAA-AD3F-42195F283E64}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "makefont", "makefont.vcxproj", "{C47ACACA-7DA4-4741-A287-9215309949E7}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "makels", "makels.vcxproj", "{8D9315B8-D428-411B-A60F-6AFD3CE0A687}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mdlviewer", "mdlviewer.vcxproj", "{348EA74B-9E7E-4F35-9474-69A5DB1B5A42}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mkmovie", "mkmovie.vcxproj", "{67FAB994-BEE5-4537-8E00-60259F66F654}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "procinfo", "procinfo.vcxproj", "{2DE8C1AF-56AE-4B99-8AA5-BEDBF33D6216}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "qbsp2", "qbsp2.vcxproj", "{415A5B85-BEA0-4F96-BBB6-5447E4CF726F}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "qcsg", "qcsg.vcxproj", "{0F44E796-FAFD-4D52-91DE-707B5FB27841}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "qlumpy", "qlumpy.vcxproj", "{01780C5F-55A2-41D4-B27F-6383BB549DE4}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "qrad", "qrad.vcxproj", "{A015F691-DF6B-4E05-AB3B-4B0A55C13EDC}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sprgen", "sprgen.vcxproj", "{2ADCE88F-5117-4D09-BE30-C8CBE902203E}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "studiomdl", "studiomdl.vcxproj", "{5A257608-0B80-42ED-A037-C2A02E878301}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "vis", "vis.vcxproj", "{6CAC4D26-13B7-4701-A097-94C01340B345}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "xwad", "xwad.vcxproj", "{8A13BDB4-772F-4D03-B343-B56A6D412149}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "serverctrl", "serverctrl.vcxproj", "{AF96A753-E234-4692-90AB-CCD802E34E9C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B1227C36-C02C-4914-9675-C6D243D8B36E}.Debug|Win32.ActiveCfg = Debug|Win32
+		{B1227C36-C02C-4914-9675-C6D243D8B36E}.Debug|Win32.Build.0 = Debug|Win32
+		{B1227C36-C02C-4914-9675-C6D243D8B36E}.Release|Win32.ActiveCfg = Release|Win32
+		{B1227C36-C02C-4914-9675-C6D243D8B36E}.Release|Win32.Build.0 = Release|Win32
+		{1D9A402B-C7AB-4DAA-AD3F-42195F283E64}.Debug|Win32.ActiveCfg = Debug|Win32
+		{1D9A402B-C7AB-4DAA-AD3F-42195F283E64}.Debug|Win32.Build.0 = Debug|Win32
+		{1D9A402B-C7AB-4DAA-AD3F-42195F283E64}.Release|Win32.ActiveCfg = Release|Win32
+		{1D9A402B-C7AB-4DAA-AD3F-42195F283E64}.Release|Win32.Build.0 = Release|Win32
+		{C47ACACA-7DA4-4741-A287-9215309949E7}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C47ACACA-7DA4-4741-A287-9215309949E7}.Debug|Win32.Build.0 = Debug|Win32
+		{C47ACACA-7DA4-4741-A287-9215309949E7}.Release|Win32.ActiveCfg = Release|Win32
+		{C47ACACA-7DA4-4741-A287-9215309949E7}.Release|Win32.Build.0 = Release|Win32
+		{8D9315B8-D428-411B-A60F-6AFD3CE0A687}.Debug|Win32.ActiveCfg = Debug|Win32
+		{8D9315B8-D428-411B-A60F-6AFD3CE0A687}.Debug|Win32.Build.0 = Debug|Win32
+		{8D9315B8-D428-411B-A60F-6AFD3CE0A687}.Release|Win32.ActiveCfg = Release|Win32
+		{8D9315B8-D428-411B-A60F-6AFD3CE0A687}.Release|Win32.Build.0 = Release|Win32
+		{348EA74B-9E7E-4F35-9474-69A5DB1B5A42}.Debug|Win32.ActiveCfg = Debug|Win32
+		{348EA74B-9E7E-4F35-9474-69A5DB1B5A42}.Debug|Win32.Build.0 = Debug|Win32
+		{348EA74B-9E7E-4F35-9474-69A5DB1B5A42}.Release|Win32.ActiveCfg = Release|Win32
+		{348EA74B-9E7E-4F35-9474-69A5DB1B5A42}.Release|Win32.Build.0 = Release|Win32
+		{67FAB994-BEE5-4537-8E00-60259F66F654}.Debug|Win32.ActiveCfg = Debug|Win32
+		{67FAB994-BEE5-4537-8E00-60259F66F654}.Debug|Win32.Build.0 = Debug|Win32
+		{67FAB994-BEE5-4537-8E00-60259F66F654}.Release|Win32.ActiveCfg = Release|Win32
+		{67FAB994-BEE5-4537-8E00-60259F66F654}.Release|Win32.Build.0 = Release|Win32
+		{2DE8C1AF-56AE-4B99-8AA5-BEDBF33D6216}.Debug|Win32.ActiveCfg = Debug|Win32
+		{2DE8C1AF-56AE-4B99-8AA5-BEDBF33D6216}.Debug|Win32.Build.0 = Debug|Win32
+		{2DE8C1AF-56AE-4B99-8AA5-BEDBF33D6216}.Release|Win32.ActiveCfg = Release|Win32
+		{2DE8C1AF-56AE-4B99-8AA5-BEDBF33D6216}.Release|Win32.Build.0 = Release|Win32
+		{415A5B85-BEA0-4F96-BBB6-5447E4CF726F}.Debug|Win32.ActiveCfg = Debug|Win32
+		{415A5B85-BEA0-4F96-BBB6-5447E4CF726F}.Debug|Win32.Build.0 = Debug|Win32
+		{415A5B85-BEA0-4F96-BBB6-5447E4CF726F}.Release|Win32.ActiveCfg = Release|Win32
+		{415A5B85-BEA0-4F96-BBB6-5447E4CF726F}.Release|Win32.Build.0 = Release|Win32
+		{0F44E796-FAFD-4D52-91DE-707B5FB27841}.Debug|Win32.ActiveCfg = Debug|Win32
+		{0F44E796-FAFD-4D52-91DE-707B5FB27841}.Debug|Win32.Build.0 = Debug|Win32
+		{0F44E796-FAFD-4D52-91DE-707B5FB27841}.Release|Win32.ActiveCfg = Release|Win32
+		{0F44E796-FAFD-4D52-91DE-707B5FB27841}.Release|Win32.Build.0 = Release|Win32
+		{01780C5F-55A2-41D4-B27F-6383BB549DE4}.Debug|Win32.ActiveCfg = Debug|Win32
+		{01780C5F-55A2-41D4-B27F-6383BB549DE4}.Debug|Win32.Build.0 = Debug|Win32
+		{01780C5F-55A2-41D4-B27F-6383BB549DE4}.Release|Win32.ActiveCfg = Release|Win32
+		{01780C5F-55A2-41D4-B27F-6383BB549DE4}.Release|Win32.Build.0 = Release|Win32
+		{A015F691-DF6B-4E05-AB3B-4B0A55C13EDC}.Debug|Win32.ActiveCfg = Debug|Win32
+		{A015F691-DF6B-4E05-AB3B-4B0A55C13EDC}.Debug|Win32.Build.0 = Debug|Win32
+		{A015F691-DF6B-4E05-AB3B-4B0A55C13EDC}.Release|Win32.ActiveCfg = Release|Win32
+		{A015F691-DF6B-4E05-AB3B-4B0A55C13EDC}.Release|Win32.Build.0 = Release|Win32
+		{2ADCE88F-5117-4D09-BE30-C8CBE902203E}.Debug|Win32.ActiveCfg = Debug|Win32
+		{2ADCE88F-5117-4D09-BE30-C8CBE902203E}.Debug|Win32.Build.0 = Debug|Win32
+		{2ADCE88F-5117-4D09-BE30-C8CBE902203E}.Release|Win32.ActiveCfg = Release|Win32
+		{2ADCE88F-5117-4D09-BE30-C8CBE902203E}.Release|Win32.Build.0 = Release|Win32
+		{5A257608-0B80-42ED-A037-C2A02E878301}.Debug|Win32.ActiveCfg = Debug|Win32
+		{5A257608-0B80-42ED-A037-C2A02E878301}.Debug|Win32.Build.0 = Debug|Win32
+		{5A257608-0B80-42ED-A037-C2A02E878301}.Release|Win32.ActiveCfg = Release|Win32
+		{5A257608-0B80-42ED-A037-C2A02E878301}.Release|Win32.Build.0 = Release|Win32
+		{6CAC4D26-13B7-4701-A097-94C01340B345}.Debug|Win32.ActiveCfg = Debug|Win32
+		{6CAC4D26-13B7-4701-A097-94C01340B345}.Debug|Win32.Build.0 = Debug|Win32
+		{6CAC4D26-13B7-4701-A097-94C01340B345}.Release|Win32.ActiveCfg = Release|Win32
+		{6CAC4D26-13B7-4701-A097-94C01340B345}.Release|Win32.Build.0 = Release|Win32
+		{8A13BDB4-772F-4D03-B343-B56A6D412149}.Debug|Win32.ActiveCfg = Debug|Win32
+		{8A13BDB4-772F-4D03-B343-B56A6D412149}.Debug|Win32.Build.0 = Debug|Win32
+		{8A13BDB4-772F-4D03-B343-B56A6D412149}.Release|Win32.ActiveCfg = Release|Win32
+		{8A13BDB4-772F-4D03-B343-B56A6D412149}.Release|Win32.Build.0 = Release|Win32
+		{AF96A753-E234-4692-90AB-CCD802E34E9C}.Debug|Win32.ActiveCfg = Debug|Win32
+		{AF96A753-E234-4692-90AB-CCD802E34E9C}.Debug|Win32.Build.0 = Debug|Win32
+		{AF96A753-E234-4692-90AB-CCD802E34E9C}.Release|Win32.ActiveCfg = Release|Win32
+		{AF96A753-E234-4692-90AB-CCD802E34E9C}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8DCBC26D-0583-4294-9E4F-EA3D8AFEE142}
+	EndGlobalSection
+EndGlobal

--- a/projects/vs2019/vis.vcxproj
+++ b/projects/vs2019/vis.vcxproj
@@ -1,0 +1,107 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\bspfile.c" />
+    <ClCompile Include="..\..\utils\common\cmdlib.c" />
+    <ClCompile Include="..\..\utils\common\mathlib.c" />
+    <ClCompile Include="..\..\utils\common\scriplib.c" />
+    <ClCompile Include="..\..\utils\common\threads.c" />
+    <ClCompile Include="..\..\utils\visx2\flow.c" />
+    <ClCompile Include="..\..\utils\visx2\soundpvs.c" />
+    <ClCompile Include="..\..\utils\visx2\vis.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\bspfile.h" />
+    <ClInclude Include="..\..\utils\common\bsplib.h" />
+    <ClInclude Include="..\..\utils\common\cmdlib.h" />
+    <ClInclude Include="..\..\utils\common\mathlib.h" />
+    <ClInclude Include="..\..\utils\common\scriplib.h" />
+    <ClInclude Include="..\..\utils\common\threads.h" />
+    <ClInclude Include="..\..\utils\qbsp2\bsp5.h" />
+    <ClInclude Include="..\..\utils\visx2\vis.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{6CAC4D26-13B7-4701-A097-94C01340B345}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>bspinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/vis.vcxproj.filters
+++ b/projects/vs2019/vis.vcxproj.filters
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{d5586ccb-fc7d-4e19-8bde-8656f3036ed7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{23430839-825c-42f8-87f8-5ae8dbcbb612}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\common">
+      <UniqueIdentifier>{b9529791-81ac-4e1b-86b7-e3ae05d40193}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\common">
+      <UniqueIdentifier>{9e2cd4d4-3990-41a2-ae01-1cdcaeb123b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\vis">
+      <UniqueIdentifier>{6a461af5-7f20-49f1-b81b-684bd6dacbcc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\vis">
+      <UniqueIdentifier>{c1ec9e3b-b79b-41c2-9151-22820cd13949}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\qbsp2">
+      <UniqueIdentifier>{da7d197c-82da-4691-afd9-0249b0436923}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\threads.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\bspfile.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\cmdlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\mathlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\scriplib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\visx2\vis.c">
+      <Filter>Source Files\utils\vis</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\visx2\flow.c">
+      <Filter>Source Files\utils\vis</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\visx2\soundpvs.c">
+      <Filter>Source Files\utils\vis</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\utils\common\threads.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\bsplib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\visx2\vis.h">
+      <Filter>Header Files\utils\vis</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\scriplib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\bspfile.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\cmdlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\common\mathlib.h">
+      <Filter>Header Files\utils\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\utils\qbsp2\bsp5.h">
+      <Filter>Header Files\utils\qbsp2</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/vs2019/xwad.vcxproj
+++ b/projects/vs2019/xwad.vcxproj
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\cmdlib.c" />
+    <ClCompile Include="..\..\utils\common\lbmlib.c" />
+    <ClCompile Include="..\..\utils\common\wadlib.c" />
+    <ClCompile Include="..\..\utils\xwad\xwad.c" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{8A13BDB4-772F-4D03-B343-B56A6D412149}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>bspinfo</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\int\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;DOUBLEVEC_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;DOUBLEVEC_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../../utils/common</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2019/xwad.vcxproj.filters
+++ b/projects/vs2019/xwad.vcxproj.filters
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{d5586ccb-fc7d-4e19-8bde-8656f3036ed7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{23430839-825c-42f8-87f8-5ae8dbcbb612}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\common">
+      <UniqueIdentifier>{b9529791-81ac-4e1b-86b7-e3ae05d40193}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\common">
+      <UniqueIdentifier>{9e2cd4d4-3990-41a2-ae01-1cdcaeb123b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\utils\xwad">
+      <UniqueIdentifier>{ec10acce-757c-4a52-8d45-a0ff3057eef4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils\xwad">
+      <UniqueIdentifier>{a00d342e-ddd3-4ad1-8c9e-28f591981c0a}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\utils\common\wadlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\cmdlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\common\lbmlib.c">
+      <Filter>Source Files\utils\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\utils\xwad\xwad.c">
+      <Filter>Source Files\utils\xwad</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/ricochet/cl_dll/cl_util.h
+++ b/ricochet/cl_dll/cl_util.h
@@ -158,7 +158,6 @@ inline void PlaySound( int iSound, float vol ) { gEngfuncs.pfnPlaySoundByIndex( 
 
 #define max(a, b)  (((a) > (b)) ? (a) : (b))
 #define min(a, b)  (((a) < (b)) ? (a) : (b))
-#define fabs(x)	   ((x) > 0 ? (x) : 0 - (x))
 
 void ScaleColors( int &r, int &g, int &b, int a );
 

--- a/ricochet/cl_dll/in_camera.cpp
+++ b/ricochet/cl_dll/in_camera.cpp
@@ -112,7 +112,7 @@ float MoveToward( float cur, float goal, float maxspeed )
 {
 	if( cur != goal )
 	{
-		if( abs( cur - goal ) > 180.0 )
+		if( fabs( cur - goal ) > 180.0 )
 		{
 			if( cur < goal )
 				cur += 360.0;
@@ -394,7 +394,7 @@ void EXPORT CAM_Think( void )
 		if( camAngles[ PITCH ] - viewangles[ PITCH ] != cam_idealpitch->value )
 			camAngles[ PITCH ] = MoveToward( camAngles[ PITCH ], cam_idealpitch->value + viewangles[ PITCH ], CAM_ANGLE_SPEED );
 
-		if( abs( camAngles[ 2 ] - cam_idealdist->value ) < 2.0 )
+		if( fabs( camAngles[ 2 ] - cam_idealdist->value ) < 2.0 )
 			camAngles[ 2 ] = cam_idealdist->value;
 		else
 			camAngles[ 2 ] += ( cam_idealdist->value - camAngles[ 2 ] ) / 4.0;

--- a/ricochet/cl_dll/inputw32.cpp
+++ b/ricochet/cl_dll/inputw32.cpp
@@ -748,7 +748,7 @@ void IN_JoyMove ( float frametime, usercmd_t *cmd )
 				// y=ax^b; where a = 300 and b = 1.3
 				// also x values are in increments of 800 (so this is factored out)
 				// then bounds check result to level out excessively high spin rates
-				fTemp = 300.0 * pow(abs(fAxisValue) / 800.0, 1.3);
+				fTemp = 300.0 * pow(fabs(fAxisValue) / 800.0, 1.3);
 				if (fTemp > 14000.0)
 					fTemp = 14000.0;
 				// restore direction information

--- a/ricochet/dlls/bmodels.cpp
+++ b/ricochet/dlls/bmodels.cpp
@@ -550,13 +550,13 @@ void CFuncRotating :: RampPitchVol (int fUp)
 	
 	// get current angular velocity
 
-	vecCur = abs(vecAVel.x != 0 ? vecAVel.x : (vecAVel.y != 0 ? vecAVel.y : vecAVel.z));
+	vecCur = fabs(vecAVel.x != 0 ? vecAVel.x : (vecAVel.y != 0 ? vecAVel.y : vecAVel.z));
 	
 	// get target angular velocity
 
 	vecFinal = (pev->movedir.x != 0 ? pev->movedir.x : (pev->movedir.y != 0 ? pev->movedir.y : pev->movedir.z));
 	vecFinal *= pev->speed;
-	vecFinal = abs(vecFinal);
+	vecFinal = fabs(vecFinal);
 
 	// calc volume and pitch as % of final vol and pitch
 
@@ -592,9 +592,9 @@ void CFuncRotating :: SpinUp( void )
 	vecAVel = pev->avelocity;// cache entity's rotational velocity
 
 	// if we've met or exceeded target speed, set target speed and stop thinking
-	if (	abs(vecAVel.x) >= abs(pev->movedir.x * pev->speed)	&&
-			abs(vecAVel.y) >= abs(pev->movedir.y * pev->speed)	&&
-			abs(vecAVel.z) >= abs(pev->movedir.z * pev->speed) )
+	if (	fabs(vecAVel.x) >= fabs(pev->movedir.x * pev->speed)	&&
+			fabs(vecAVel.y) >= fabs(pev->movedir.y * pev->speed)	&&
+			fabs(vecAVel.z) >= fabs(pev->movedir.z * pev->speed) )
 	{
 		pev->avelocity = pev->movedir * pev->speed;// set speed in case we overshot
 		EMIT_SOUND_DYN(ENT(pev), CHAN_STATIC, (char *)STRING(pev->noiseRunning), 

--- a/ricochet/dlls/func_break.cpp
+++ b/ricochet/dlls/func_break.cpp
@@ -590,7 +590,7 @@ void CBreakable::Die( void )
 	// The more negative pev->health, the louder
 	// the sound should be.
 
-	fvol = RANDOM_FLOAT(0.85, 1.0) + (abs(pev->health) / 100.0);
+	fvol = RANDOM_FLOAT(0.85, 1.0) + (fabs(pev->health) / 100.0);
 
 	if (fvol > 1.0)
 		fvol = 1.0;

--- a/ricochet/dlls/plats.cpp
+++ b/ricochet/dlls/plats.cpp
@@ -1126,7 +1126,7 @@ void CFuncTrackTrain :: UpdateSound( void )
 	if (!pev->noise)
 		return;
 
-	flpitch = TRAIN_STARTPITCH + (abs(pev->speed) * (TRAIN_MAXPITCH - TRAIN_STARTPITCH) / TRAIN_MAXSPEED);
+	flpitch = TRAIN_STARTPITCH + (fabs(pev->speed) * (TRAIN_MAXPITCH - TRAIN_STARTPITCH) / TRAIN_MAXSPEED);
 
 	if (!m_soundPlaying)
 	{

--- a/ricochet/dlls/player.cpp
+++ b/ricochet/dlls/player.cpp
@@ -2117,7 +2117,7 @@ void CBasePlayer::CheckTimeBasedDamage()
 		return;
 
 	// only check for time based damage approx. every 2 seconds
-	if (abs(gpGlobals->time - m_tbdPrev) < 2.0)
+	if (fabs(gpGlobals->time - m_tbdPrev) < 2.0)
 		return;
 	
 	m_tbdPrev = gpGlobals->time;

--- a/utils/qbsp2/bsp5.h
+++ b/utils/qbsp2/bsp5.h
@@ -15,6 +15,8 @@
 #include "bspfile.h"
 #include "threads.h"
 
+#pragma comment(lib, "legacy_stdio_definitions.lib")
+
 //#define	ON_EPSILON	0.05
 #define	BOGUS_RANGE	18000
 

--- a/utils/qcsg/csg.h
+++ b/utils/qcsg/csg.h
@@ -18,6 +18,8 @@
 
 #include <windows.h>
 
+#pragma comment(lib, "legacy_stdio_definitions.lib")
+
 #ifndef DOUBLEVEC_T
 #error you must add -dDOUBLEVEC_T to the project!
 #endif

--- a/utils/serverctrl/ServerCtrlDlg.cpp
+++ b/utils/serverctrl/ServerCtrlDlg.cpp
@@ -80,7 +80,7 @@ int CServerCtrlDlg::RunModalLoop(DWORD dwFlags)
 	BOOL bShowIdle = (dwFlags & MLF_SHOWONIDLE) && !(GetStyle() & WS_VISIBLE);
 	HWND hWndParent = ::GetParent(m_hWnd);
 	m_nFlags |= (WF_MODALLOOP|WF_CONTINUEMODAL);
-	MSG* pMsg = &AfxGetThread()->m_msgCur;
+	MSG* pMsg = AfxGetCurrentMessage();
 
 	// acquire and dispatch messages until the modal state is done
 	for (;;)


### PR DESCRIPTION
# Provide GitHub action to this halflife repo to build artifacts

## What This Does

Provides a way to automatically build the full project with proper artifacts on a GitHub action workload.

- Creates a parallel flow that builds most targets in this repo
- Builds Windows (dlls), Linux (so's) and macOS (dylibs) for games valve, dmc, and ricochet
- Builds Windows util tools
- Builds both Debug and Release targets for all
- Provides downloadable packages at the end of the workload
- Creates separate `projects/vs2019` folder for all targets for modernization
- Minor tool/code changes
    - Bump `g++` from 4.6 to 4.8
    - macOS build 
        - Added `-mno-sse`
        - Added `CommandLineTools` conditional for workflow build compatibility
    - Minor updates from `abs()` to `fabs()`
    - [Minor legacy](https://stackoverflow.com/a/49399046) `#pragmas` added to some tools for compatability
    - [Bump from](https://stackoverflow.com/a/66946004) `AfxGetCurrentMessage()->m_msgCur` to `AfxGetCurrentMessage`

## Screenshot

![The build-halflife GitHub action](https://user-images.githubusercontent.com/729372/122678972-eae41000-d1b6-11eb-8e8d-01d01204f2a1.png)

[An example run can be found here.](https://github.com/solidi/coldice-goldsrc/actions/runs/954631590)

## What To Note

- Does not build Windows util `smdlexp` because 3D MAX 4.2 SDK is not available. (If it is, I will update)
- Performed testing to confirm libraries and exe's are operating. A more in-depth test would be a good idea
- I'm happy to take on requests to fill in the remaining gaps that I missed to achieve a full build

cc: @mikela-valve