### PR TITLE
Document stufftext filtering for modders

### DIFF
--- a/common/cvardef.h
+++ b/common/cvardef.h
@@ -25,6 +25,8 @@
 #define FCVAR_PRINTABLEONLY (1<<7)  // This cvar's string cannot contain unprintable characters ( e.g., used for player name etc ).
 #define FCVAR_UNLOGGED		(1<<8)  // If this is a FCVAR_SERVER, don't log changes to the log file / console if we are creating a log
 #define FCVAR_NOEXTRAWHITEPACE	(1<<9)  // strip trailing/leading white space from this cvar
+#define FCVAR_PRIVILEGED        (1<<10) // only available in privileged mode
+#define FCVAR_FILTERABLE        (1<<11) // filtered in unprivileged mode if cl_filterstuffcmd is 1
 
 typedef struct cvar_s
 {

--- a/engine/APIProxy.h
+++ b/engine/APIProxy.h
@@ -353,6 +353,7 @@ typedef void						(*pfnEngSrc_pfnFillRGBABlend_t )			( int x, int y, int width, 
 typedef int						(*pfnEngSrc_pfnGetAppID_t)			( void );
 typedef cmdalias_t*				(*pfnEngSrc_pfnGetAliases_t)		( void );
 typedef void					(*pfnEngSrc_pfnVguiWrap2_GetMouseDelta_t) ( int *x, int *y );
+typedef int					(*pfnEngSrc_pfnFilteredClientCmd_t)	( char * );
 
 // Pointers to the exported engine functions themselves
 typedef struct cl_enginefuncs_s
@@ -491,6 +492,7 @@ typedef struct cl_enginefuncs_s
 	pfnEngSrc_pfnGetAppID_t					pfnGetAppID;
 	pfnEngSrc_pfnGetAliases_t				pfnGetAliasList;
 	pfnEngSrc_pfnVguiWrap2_GetMouseDelta_t pfnVguiWrap2_GetMouseDelta;
+	pfnEngSrc_pfnFilteredClientCmd_t pfnFilteredClientCmd;
 } cl_enginefunc_t;
 
 // Function type declarations for engine destination functions
@@ -610,7 +612,7 @@ typedef void	(*pfnEngDst_pfnFillRGBABlend_t )				( int *, int *, int *, int *, i
 typedef void	(*pfnEngDst_pfnGetAppID_t )				( void );
 typedef void	(*pfnEngDst_pfnGetAliases_t )				( void );
 typedef void	(*pfnEngDst_pfnVguiWrap2_GetMouseDelta_t) ( int *x, int *y );
-
+typedef void	(*pfnEngDst_pfnFilteredClientCmd_t)		( char ** );
 
 // Pointers to the engine destination functions
 typedef struct
@@ -737,6 +739,7 @@ typedef struct
 	pfnEngDst_pfnGetAppID_t							pfnGetAppID;
 	pfnEngDst_pfnGetAliases_t				pfnGetAliasList;
 	pfnEngDst_pfnVguiWrap2_GetMouseDelta_t	pfnVguiWrap2_GetMouseDelta;
+	pfnEngDst_pfnFilteredClientCmd_t pfnFilteredClientCmd;
 } cl_enginefunc_dst_t;
 
 

--- a/engine/cdll_int.h
+++ b/engine/cdll_int.h
@@ -410,6 +410,7 @@ extern void NullDst(void);
 	(pfnEngDst_pfnGetAppID_t)						NullDst, \
 	(pfnEngDst_pfnGetAliases_t)						NullDst, \
 	(pfnEngDst_pfnVguiWrap2_GetMouseDelta_t)		NullDst, \
+	(pfnEngDst_pfnFilteredClientCmd_t)			NullDst, \
 };
 
 // Use this to init a cldll_func_dst structure to point to NullDst


### PR DESCRIPTION
(of course, nobody will merge it but I'll leave it there for any modders who want to play with this)

**New flags**

cl_filterstuffcmd update added two new important CVar flags: `FCVAR_PRIVILEGED` using 10-th bit and `FCVAR_FILTERABLE` using 11-th bit.  This way, client.dll and engine can protect cvars from malicious servers.

* Privileged cvars and commands will never be set or executed from network and will never be sent over network through cvar query. \
Engine privileged cvars: `cl_filterstuffcmd`, `sv_logsecret`, `rcon_password`, `rcon_address`, `rcon_port`.

* Filterable cvars and commands will be filtered out only if cl_filterstuffcmd is more than zero. They are accessible through cvar query. \
Cvars and commands that start with `cl_`, `gl_`, `r_`, `m_` and `hud_` are interpreted as filterable automatically. \
Engine filterable cvars: `MP3Volume`, `speak_enabled`, `volume`, `ex_interp`, `developer`, `fps_max`, `sys_ticrate`, `voice_enable`, `password`, `rate`.

**Unprivileged mode**

Engine now have separated unprivileged command buffer for commands coming from network. Unprivileged mode is enabled for: svc_stufftext, Director stufftext (with client patch using pfnFilteredClientCmd) and demos stufftext

Unprivileged mode propagated to messagemode/messagemode2 commands that may also sent from network. \
In unprivileged mode exec command only allows config filenames in hardcoded whitelist: all TFC classes names, mapdefault.cfg and current map config file. Interestingly, it doesn't check for gamedir and doesn't propagate unprivileged flag so still can be exploited in other games. ;)

Stufftext is validated through validator function. If it contains `alias `, `connect`, `reconnect`, `bind`, `_set`, `unbind`, `retry`, `quit`, `kill`, `exit`, `writecfg`, `cl_filterstuffcmd`, `unbindall`, `_restart`, `motd_write` or `motdfile` it's automatically discarded and not even passed to command buffer.