### PR TITLE
Fixed wrong base class specified in CWallHealth save restore.

### DIFF
--- a/dlls/healthkit.cpp
+++ b/dlls/healthkit.cpp
@@ -132,7 +132,7 @@ TYPEDESCRIPTION CWallHealth::m_SaveData[] =
 	DEFINE_FIELD( CWallHealth, m_flSoundTime, FIELD_TIME),
 };
 
-IMPLEMENT_SAVERESTORE( CWallHealth, CBaseEntity );
+IMPLEMENT_SAVERESTORE( CWallHealth, CBaseToggle );
 
 LINK_ENTITY_TO_CLASS(func_healthcharger, CWallHealth);
 


### PR DESCRIPTION
See issue #3197.