### PR TITLE
Fixed wrong base class specified in CRecharge save restore.

### DIFF
--- a/dlls/h_battery.cpp
+++ b/dlls/h_battery.cpp
@@ -58,7 +58,7 @@ TYPEDESCRIPTION CRecharge::m_SaveData[] =
 	DEFINE_FIELD( CRecharge, m_flSoundTime, FIELD_TIME ),
 };
 
-IMPLEMENT_SAVERESTORE( CRecharge, CBaseEntity );
+IMPLEMENT_SAVERESTORE( CRecharge, CBaseToggle );
 
 LINK_ENTITY_TO_CLASS(func_recharge, CRecharge);
 


### PR DESCRIPTION
See issue #3199.