### PR TITLE
Fixed wrong base class specified in CEnvSound save restore.

### DIFF
--- a/dlls/sound.cpp
+++ b/dlls/sound.cpp
@@ -826,7 +826,7 @@ TYPEDESCRIPTION	CEnvSound::m_SaveData[] =
 	DEFINE_FIELD( CEnvSound, m_flRoomtype, FIELD_FLOAT ),
 };
 
-IMPLEMENT_SAVERESTORE( CEnvSound, CBaseEntity );
+IMPLEMENT_SAVERESTORE( CEnvSound, CPointEntity );
 
 
 void CEnvSound :: KeyValue( KeyValueData *pkvd )


### PR DESCRIPTION
See issue #3203.