### PR TITLE
fix: crash from invalid weapon access and fixes ValveSoftware#3819 

### DIFF
--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -832,7 +832,7 @@ void CBasePlayer::PackDeadPlayerItems( void )
 
 		if ( iAmmoRules == GR_PLR_DROP_AMMO_ACTIVE && iWeaponRules == GR_PLR_DROP_GUN_ACTIVE )
 		{
-			if ( FClassnameIs( rgpPackWeapons[0]->pev, "weapon_satchel" ) && ( iPackAmmo[0] == -1 || ( m_rgAmmo[iPackAmmo[0]] == 0 ) ) )
+			if ( m_pActiveItem && FClassnameIs( rgpPackWeapons[0]->pev, "weapon_satchel" ) && ( iPackAmmo[0] == -1 || ( m_rgAmmo[iPackAmmo[0]] == 0 ) ) )
 			{
 				bPackItems = FALSE;
 			}
@@ -3301,6 +3301,9 @@ void CBasePlayer::SelectItem(const char *pstr)
 	if (pItem == m_pActiveItem)
 		return;
 
+	if (!pItem->CanDeploy())
+		return;
+
 	ResetAutoaim( );
 
 	// FIX, this needs to queue them up and delay
@@ -3329,6 +3332,9 @@ void CBasePlayer::SelectLastItem(void)
 	{
 		return;
 	}
+
+	if (!m_pLastItem->CanDeploy())
+		return;
 
 	ResetAutoaim( );
 


### PR DESCRIPTION
## Description

This pull request fixes a crash that was introduced in the 25th Anniversary Update of Half-Life, which occurs when a player dies while switching to a weapon that has run out of ammo. The crash stems from an invalid dereference of a null pointer when attempting to pack the dead player's weapons into a weapon box. Specifically, `rgpPackWeapons[0]` is null, leading to an invalid pev access.

After extensive tracing, the root cause of the issue has been identified when switching back to a weapon with zero ammo, the weapon's `Holster()` function calls the following chain of events:

`DestroyItem()` -> `RemovePlayerItem()` -> `m_pActiveItem = NULL`

## Related Issue
Fixes issue #3819

## Explanation of Changes

- Added a check for `m_pActiveItem` to prevent dereferencing a null pointer when packing dead player's weapons

    The crash occurs due to an invalid `pev` pointer, where `rgpPackWeapons[0]` is `NULL` while attempting to dereference it. Upon death, [`rgpPackWeapons[nIndex] = pWeapon`](https://github.com/ValveSoftware/halflife/blob/e5815c34e2772a247a6843b67eab7c3395bdba66/dlls/player.cpp#L727) is never assigned because it is inside a condition that checks whether [`m_pActiveItem`](https://github.com/ValveSoftware/halflife/blob/e5815c34e2772a247a6843b67eab7c3395bdba66/dlls/player.cpp#L721) is not `NULL`.

    The chain leading to `m_pActiveItem` being `NULL` starts when a weapon is switched back to with `0` ammo. When this happens, the weapon's `Holster()` function calls [`DestroyItem()`](https://github.com/ValveSoftware/halflife/blob/e5815c34e2772a247a6843b67eab7c3395bdba66/dlls/squeakgrenade.cpp#L486), which in turn calls [`RemovePlayerItem()`](https://github.com/ValveSoftware/halflife/blob/e5815c34e2772a247a6843b67eab7c3395bdba66/dlls/weapons.cpp#L746). This function sets [`m_pActiveItem = NULL`](https://github.com/ValveSoftware/halflife/blob/e5815c34e2772a247a6843b67eab7c3395bdba66/dlls/player.cpp#L3907), meaning that when the player dies or kills themselves, the `PackDeadPlayerItems()` function doesn't assign `pWeapon` to `rgpPackWeapons[nIndex]`. As a result, `rgpPackWeapons[0]` remains `NULL`, leading to the crash when trying to dereference `rgpPackWeapons[0]->pev`.

- Added a validation in `CBasePlayer::SelectItem` and `CBasePlayer::SelectLastItem` to ensure the selected weapon can be deployed before switching to it.

    The issue is also caused by players switching to unusable weapons (such as one with no ammo or one that has been destroyed), leading to crashes and unexpected behavior described in issue #3819. Adding `CanDeploy()` validation ensures that the player only switches to valid, deployable weapons. This prevents crashes due to switching to weapons that cannot be used (e.g., no ammo or destroyed weapons), avoiding invalid weapon access issues.