### PR TITLE
Linux: leave the default symbol visibility to improve modding with tools

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -35,8 +35,8 @@ ELF-GC-DYNSTR=./elf-gc-dynstr
 
 # Note that we expect to be building inside a Steam Runtime "scout" container
 ifeq ($(OS),Linux)
-		CC="gcc-5 -m32 -std=gnu++11 -fno-delete-null-pointer-checks -fno-gnu-unique -fvisibility=hidden"
-		CPLUS="g++-5 -m32 -std=gnu++11 -fno-delete-null-pointer-checks -fno-gnu-unique -fvisibility=hidden"
+		CC="gcc-5 -m32 -std=gnu++11 -fno-delete-null-pointer-checks -fno-gnu-unique"
+		CPLUS="g++-5 -m32 -std=gnu++11 -fno-delete-null-pointer-checks -fno-gnu-unique"
 		CPP_LIB:=-L$(shell g++-5 -m32 -print-file-name=libstdc++.so | xargs dirname) -lstdc++ -ldl -lpthread
 				CLINK=$(CC)
 endif


### PR DESCRIPTION
Closes #3562

At first I thought it might be because of the lack of `-Wl,--export-dynamic` and `-fPIC` as linker flags, although adding them had no effect. Then I started to lower the optimization levels, suspecting that this was due to the highest optimization level - that's not the issue either. Flags for debug information in the form `-gdwarf-2 -g2` were also enabled.

Until I noticed **-fvisibility=hidden** and then it became clear to me why most of the function symbols in the `.dynsym` section were missing. Yeah....

@shawns-valve - these changes should also be applied to the engine as well, not just to game libraries!
