### PR TITLE
Fix a bug

### DIFF
--- a/cl_dll/message.cpp
+++ b/cl_dll/message.cpp
@@ -148,6 +148,7 @@ void CHudMessage::MessageScanNextChar( void )
 	srcRed = m_parms.pMessage->r1;
 	srcGreen = m_parms.pMessage->g1;
 	srcBlue = m_parms.pMessage->b1;
+	destRed = destGreen = destBlue = 0;
 	blend = 0;	// Pure source
 
 	switch( m_parms.pMessage->effect )
@@ -155,7 +156,6 @@ void CHudMessage::MessageScanNextChar( void )
 	// Fade-in / Fade-out
 	case 0:
 	case 1:
-		destRed = destGreen = destBlue = 0;
 		blend = m_parms.fadeBlend;
 		break;
 
@@ -170,7 +170,6 @@ void CHudMessage::MessageScanNextChar( void )
 		{
 			float deltaTime = m_parms.time - m_parms.charTime;
 
-			destRed = destGreen = destBlue = 0;
 			if ( m_parms.time > m_parms.fadeTime )
 			{
 				blend = m_parms.fadeBlend;


### PR DESCRIPTION
HUD message color variables are left uninitialized during the first few frames, causing a crash in the debug build of client.dll.

I replaced the duplicated initialization logic with a single line placed before the branching, since the variables are used regardless of the conditions anyway.

Fixes #1536 