### PR TITLE
Add CVARs to Restore Pre-Anniversary Grenade and Satchel Charge Behaviors

### DIFF
--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -84,6 +84,7 @@ extern client_sprite_t *GetSpriteList(client_sprite_t *pList, const char *psz, i
 extern float IN_GetMouseSensitivity();
 
 cvar_t *cl_lw = NULL;
+cvar_t *legacy_satchel = NULL;
 
 void ShutdownInput (void);
 
@@ -329,6 +330,7 @@ void CHud :: Init( void )
 
 	CVAR_CREATE( "zoom_sensitivity_ratio", "1.2", FCVAR_ARCHIVE );
 	CVAR_CREATE( "cl_autowepswitch", "1", FCVAR_USERINFO|FCVAR_ARCHIVE );
+	legacy_satchel = CVAR_CREATE( "cl_legacy_satchel", "0", FCVAR_USERINFO | FCVAR_ARCHIVE );
 	default_fov = CVAR_CREATE( "default_fov", "90", FCVAR_ARCHIVE );
 	m_pCvarStealMouse = CVAR_CREATE( "hud_capturemouse", "1", FCVAR_ARCHIVE );
 	m_pCvarDraw = CVAR_CREATE( "hud_draw", "1", FCVAR_ARCHIVE );

--- a/dlls/game.cpp
+++ b/dlls/game.cpp
@@ -455,6 +455,8 @@ cvar_t sv_pushable_fixed_tick_fudge = { "sv_pushable_fixed_tick_fudge", "15" };
 
 cvar_t sv_busters = { "sv_busters", "0" };
 
+cvar_t legacy_hgrenade = { "sv_legacy_hgrenade", "0", FCVAR_SERVER };
+
 // Register your console variables here
 // This gets called one time when the game is initialied
 void GameDLLInit( void )
@@ -894,6 +896,8 @@ void GameDLLInit( void )
 // END REGISTER CVARS FOR SKILL LEVEL STUFF
 
 	CVAR_REGISTER ( &sv_pushable_fixed_tick_fudge );
+
+	CVAR_REGISTER ( &legacy_hgrenade );
 
 	SERVER_COMMAND( "exec skill.cfg\n" );
 }

--- a/dlls/gamerules.h
+++ b/dlls/gamerules.h
@@ -246,6 +246,9 @@ public:
 // Teamplay stuff	
 	virtual const char *GetTeamID( CBaseEntity *pEntity ) {return "";};
 	virtual int PlayerRelationship( CBaseEntity *pPlayer, CBaseEntity *pTarget );
+
+// Client preference
+	virtual void ClientUserInfoChanged( CBasePlayer *pPlayer, char *infobuffer );
 };
 
 //=========================================================

--- a/dlls/handgrenade.cpp
+++ b/dlls/handgrenade.cpp
@@ -140,10 +140,21 @@ void CHandGrenade::WeaponIdle( void )
 		else
 			angThrow.x = -10 + angThrow.x * ( ( 90 + 10 ) / 90.0 );
 
-		static float flMultiplier = 6.5f;
+		float flMultiplier = 6.5f;
+		float flMaxVel = 1000.0f;
+
+#ifndef CLIENT_DLL
+		extern cvar_t legacy_hgrenade;
+		if ( legacy_hgrenade.value > 0 )
+		{
+			flMultiplier = 4.0f;
+			flMaxVel = 500.0f;
+		}
+#endif
+
 		float flVel = ( 90 - angThrow.x ) * flMultiplier;
-		if ( flVel > 1000 )
-			flVel = 1000;
+		if ( flVel > flMaxVel )
+			flVel = flMaxVel;
 
 		UTIL_MakeVectors( angThrow );
 

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -4348,6 +4348,17 @@ void CBasePlayer :: SetPrefsFromUserinfo( char * infobuffer )
 	{
 		m_iAutoWepSwitch = atoi( pszKeyVal );
 	}
+
+	// Set satchel charge control preference
+	pszKeyVal = g_engfuncs.pfnInfoKeyValue( infobuffer, "cl_legacy_satchel" );
+	if ( FStrEq( pszKeyVal, "" ) )
+	{
+		m_iLegacySatchel = 0;
+	}
+	else
+	{
+		m_iLegacySatchel = atoi( pszKeyVal );
+	}
 }
 
 

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -327,6 +327,7 @@ public:
 	float m_flNextChatTime;
 	
 	int	m_iAutoWepSwitch;
+	int	m_iLegacySatchel;
 };
 
 #define AUTOAIM_2DEGREES  0.0348994967025

--- a/dlls/satchel.cpp
+++ b/dlls/satchel.cpp
@@ -23,6 +23,10 @@
 #include "player.h"
 #include "gamerules.h"
 
+#ifdef CLIENT_DLL
+extern cvar_t *legacy_satchel;
+#endif
+
 enum satchel_e {
 	SATCHEL_IDLE1 = 0,
 	SATCHEL_FIDGET1,
@@ -350,15 +354,47 @@ void CSatchel::Holster( int skiplocal /* = 0 */ )
 
 void CSatchel::PrimaryAttack()
 {
-	// we're reloading, don't allow fire
-	if( m_chargeReady != 2 )
-	{
-		Throw();
-	}
+#ifdef CLIENT_DLL
+	if ( legacy_satchel->value > 0 )
+#else
+	if ( m_pPlayer->m_iLegacySatchel > 0 )
+#endif
+		switch (m_chargeReady)
+		{
+		case 0:
+			Throw();
+			break;
+		case 1:
+			Detonate();
+			break;
+		}
+	else
+		// we're reloading, don't allow fire
+		if( m_chargeReady != 2 )
+		{
+			Throw();
+		}
 }
 
-
 void CSatchel::SecondaryAttack( void )
+{
+#ifdef CLIENT_DLL
+	if ( legacy_satchel->value > 0 )
+#else
+	if ( m_pPlayer->m_iLegacySatchel > 0 )
+#endif
+	{
+		// we're reloading, don't allow fire
+		if( m_chargeReady != 2 )
+		{
+			Throw();
+		}
+	}
+	else
+		Detonate();
+}
+
+void CSatchel::Detonate( void )
 {
 	if ( m_chargeReady == 1 )
 	{

--- a/dlls/singleplay_gamerules.cpp
+++ b/dlls/singleplay_gamerules.cpp
@@ -406,3 +406,11 @@ BOOL CHalfLifeRules :: FAllowMonsters( void )
 {
 	return TRUE;
 }
+
+//=========================================================
+//=========================================================
+void CHalfLifeRules::ClientUserInfoChanged( CBasePlayer *pPlayer, char *infobuffer )
+{
+	// Set preferences
+	pPlayer->SetPrefsFromUserinfo( infobuffer );
+}

--- a/dlls/weapons.h
+++ b/dlls/weapons.h
@@ -951,6 +951,7 @@ public:
 	void Holster( int skiplocal = 0 );
 	void WeaponIdle( void );
 	void Throw( void );
+	void Detonate( void );
 	
 	virtual BOOL UseDecrement( void )
 	{ 


### PR DESCRIPTION
This partially addresses issue #3505. This adds two CVARs to optionally restore pre-Anniversary mechanics for the hand grenade and satchel charge weapons. These are both set to `0` by default. 

- `sv_legacy_hgrenade` (server-side)
Set to `1` to restore the original (pre-Anniversary) hand grenade throwing velocity, resulting in shorter throws.

- `cl_legacy_satchel` (client-side)
Set to `1` to revert the satchel charge controls to their original behaviour:
   - Primary fire will detonate any active satchels or throw one if none are active.
   - Secondary fire will throw a satchel.

        